### PR TITLE
Add GenerateVariableInitializer option that allows skipping initial variable assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ VarDump is a utility for serialization runtime objects to C# or Visual Basic str
 
 Developed as a free alternative of [ObjectDumper.NET](https://github.com/thomasgalliker/ObjectDumper), which is not free for commercial use.
 
-[![nuget version](https://img.shields.io/badge/Nuget-v0.2.2-blue)](https://www.nuget.org/packages/VarDump)
+[![nuget version](https://img.shields.io/badge/Nuget-v0.2.3-blue)](https://www.nuget.org/packages/VarDump)
 [![nuget downloads](https://img.shields.io/nuget/dt/VarDump?label=Downloads)](https://www.nuget.org/packages/VarDump)
 
 # Powered By

--- a/src/Extensions/CodeGeneratorExtensions.cs
+++ b/src/Extensions/CodeGeneratorExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.IO;
+using VarDump.CodeDom.Common;
+using VarDump.CodeDom.Compiler;
+
+namespace VarDump.Extensions
+{
+    internal static class CodeGeneratorExtensions
+    {
+        public static void GenerateCode(this ICodeGenerator codeGenerator, CodeObject co, TextWriter w,
+            CodeGeneratorOptions o)
+        {
+            switch (co)
+            {
+                case CodeExpression ce:
+                    codeGenerator.GenerateCodeFromExpression(ce, w, o);
+                    break;
+                case CodeStatement cs:
+                    codeGenerator.GenerateCodeFromStatement(cs, w, o);
+                    break;
+                default:
+                    throw new InvalidOperationException("CodeExpression and CodeStatement supported only.");
+            }
+        }
+    }
+}

--- a/src/VarDump.csproj
+++ b/src/VarDump.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 	<AssemblyName>VarDump</AssemblyName>
-	<AssemblyVersion>0.2.2</AssemblyVersion>
-	<FileVersion>0.2.2</FileVersion>
+	<AssemblyVersion>0.2.3</AssemblyVersion>
+	<FileVersion>0.2.3</FileVersion>
 	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 	<Copyright>Copyright $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Title>VarDump</Title>
-	<Version>0.2.2</Version>
+	<Version>0.2.3</Version>
 	<Description>VarDump is a utility for serialization runtime objects to C# and Visual Basic string.</Description>
 	<PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
 	<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Visitor/DumpOptions.cs
+++ b/src/Visitor/DumpOptions.cs
@@ -23,6 +23,7 @@ namespace VarDump.Visitor
         public ListSortDirection? SortDirection { get; set; }
 
         public static DumpOptions Default { get; } = new();
+        public bool GenerateVariableInitializer { get; set; } = true;
 
         public DumpOptions Clone()
         {
@@ -30,7 +31,9 @@ namespace VarDump.Visitor
             {
                 DateKind = DateKind,
                 DateTimeInstantiation = DateTimeInstantiation,
+                Descriptors = Descriptors.ToArray(),
                 ExcludeTypes = ExcludeTypes?.ToArray() ?? new string[0],
+                GenerateVariableInitializer = GenerateVariableInitializer,
                 GetFieldsBindingFlags = GetFieldsBindingFlags,
                 GetPropertiesBindingFlags = GetPropertiesBindingFlags,
                 IgnoreDefaultValues = IgnoreDefaultValues,
@@ -39,8 +42,7 @@ namespace VarDump.Visitor
                 SortDirection = SortDirection,
                 UseNamedArgumentsForReferenceRecordTypes = UseNamedArgumentsForReferenceRecordTypes,
                 UseTypeFullName = UseTypeFullName,
-                WritablePropertiesOnly = WritablePropertiesOnly,
-                Descriptors = Descriptors.ToArray()
+                WritablePropertiesOnly = WritablePropertiesOnly
             };
         }
     }

--- a/test/UnitTests/VariableNameSpec.cs
+++ b/test/UnitTests/VariableNameSpec.cs
@@ -70,7 +70,7 @@ namespace UnitTests
         }
         
         [Fact]
-        public void DoNotGenerateVariableNameCSharp()
+        public void DoNotGenerateVariableInitializerCSharp()
         {
             var stringValue = "Test string value";
 
@@ -85,7 +85,7 @@ namespace UnitTests
         }
 
         [Fact]
-        public void DoNotGenerateVariableNameVb()
+        public void DoNotGenerateVariableInitializerVb()
         {
             var stringValue = "Test string value";
 

--- a/test/UnitTests/VariableNameSpec.cs
+++ b/test/UnitTests/VariableNameSpec.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnitTests.TestModel;
 using VarDump;
+using VarDump.Visitor;
 using Xunit;
 
 namespace UnitTests
@@ -67,6 +68,35 @@ namespace UnitTests
 
             Assert.StartsWith("var stringValue", result);
         }
+        
+        [Fact]
+        public void DoNotGenerateVariableNameCSharp()
+        {
+            var stringValue = "Test string value";
 
+            var dumper = new CSharpDumper(new DumpOptions
+            {
+                GenerateVariableInitializer = false
+            });
+
+            var result = dumper.Dump(stringValue);
+
+            Assert.Equal("\"Test string value\"", result);
+        }
+
+        [Fact]
+        public void DoNotGenerateVariableNameVb()
+        {
+            var stringValue = "Test string value";
+
+            var dumper = new VisualBasicDumper(new DumpOptions
+            {
+                GenerateVariableInitializer = false
+            });
+
+            var result = dumper.Dump(stringValue);
+
+            Assert.Equal("\"Test string value\"", result);
+        }
     }
 }


### PR DESCRIPTION
Add GenerateVariableInitializer option that allows skipping initial variable assignment