### PR TITLE
More readable date time instantiation expression

### DIFF
--- a/src/VarDump.csproj
+++ b/src/VarDump.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 	<AssemblyName>VarDump</AssemblyName>
-	<AssemblyVersion>0.2.4</AssemblyVersion>
-	<FileVersion>0.2.4</FileVersion>
+	<AssemblyVersion>0.2.5</AssemblyVersion>
+	<FileVersion>0.2.5</FileVersion>
 	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 	<Copyright>Copyright $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<Title>VarDump</Title>
-	<Version>0.2.4</Version>
+	<Version>0.2.5</Version>
 	<Description>VarDump is a utility for serialization runtime objects to C# and Visual Basic string.</Description>
 	<PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
 	<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/test/UnitTests/DateTimeSpec.cs
+++ b/test/UnitTests/DateTimeSpec.cs
@@ -1,5 +1,9 @@
+//using Microsoft.CodeAnalysis.CSharp.Scripting;
 using System;
 using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
 using VarDump;
 using VarDump.Visitor;
 using Xunit;
@@ -8,6 +12,63 @@ namespace UnitTests
 {
     public class DateTimeSpec
     {
+        [Fact]
+        public async Task DumpDateTimeCsharp()
+        {
+            var dateTime = DateTime.ParseExact("2023-08-05T12:47:09.9361937+02:00", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+            var dumper = new CSharpDumper(new DumpOptions
+            {
+                UseTypeFullName = false,
+                DateTimeInstantiation = DateTimeInstantiation.New,
+                DateKind = DateKind.ConvertToUtc,
+                GenerateVariableInitializer = false
+            });
+
+            var expectedResult = "new DateTime(2023, 8, 5, 10, 47, 9, 936, DateTimeKind.Utc).AddTicks(1937)";
+
+            var result = dumper.Dump(dateTime);
+
+            var evaluatedResult = await CSharpScript.EvaluateAsync<DateTime>(result, ScriptOptions.Default.WithImports("System"));
+
+            Assert.Equal(dateTime.ToUniversalTime(), evaluatedResult.ToUniversalTime());
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void DumpDateTimeVb()
+        {
+            var dateTime = DateTime.ParseExact("2023-08-05T12:47:09.9361937+02:00", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
+            var dumper = new VisualBasicDumper(new DumpOptions
+            {
+                UseTypeFullName = false,
+                DateTimeInstantiation = DateTimeInstantiation.New,
+                DateKind = DateKind.ConvertToUtc,
+                GenerateVariableInitializer = false
+            });
+
+            var expectedResult = "New Date(2023, 8, 5, 10, 47, 9, 936, DateTimeKind.Utc).AddTicks(1937)";
+
+            var result = dumper.Dump(dateTime);
+
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void DumpDateTimeOffsetCsharp()
+        {
+            var dto = DateTimeOffset.ParseExact("2022-06-24T11:59:21.7961218+03:00", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            
+            var dumper = new CSharpDumper();
+
+            var result = dumper.Dump(dto);
+
+            Assert.Equal(
+@"var dateTimeOffset = DateTimeOffset.ParseExact(""2022-06-24T11:59:21.7961218+03:00"", ""O"", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+", result);
+        }
+
         [Fact]
         public void DumpDateOnlyCsharp()
         {
@@ -25,24 +86,10 @@ namespace UnitTests
             var result = dumper.Dump(anonymous);
 
             Assert.Equal(
-@"var anonymousType = new 
+                @"var anonymousType = new 
 {
     DateOnly = DateOnly.ParseExact(""2022-12-10"", ""O"")
 };
-", result);
-        }
-        
-        [Fact]
-        public void DumpDateTimeOffsetCsharp()
-        {
-            var dto = DateTimeOffset.ParseExact("2022-06-24T11:59:21.7961218+03:00", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-            
-            var dumper = new CSharpDumper();
-
-            var result = dumper.Dump(dto);
-
-            Assert.Equal(
-@"var dateTimeOffset = DateTimeOffset.ParseExact(""2022-06-24T11:59:21.7961218+03:00"", ""O"", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
 ", result);
         }
 

--- a/test/UnitTests/ObjectDescriptorMiddlewareSpec.cs
+++ b/test/UnitTests/ObjectDescriptorMiddlewareSpec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -86,7 +87,8 @@ namespace UnitTests
             {
                 Descriptors = { new FileSystemInfoMiddleware() },
                 DateKind = DateKind.ConvertToUtc,
-                WritablePropertiesOnly = false
+                WritablePropertiesOnly = false,
+                SortDirection = ListSortDirection.Ascending
             };
 
             var directoryName = Guid.NewGuid().ToString();
@@ -98,16 +100,16 @@ namespace UnitTests
             var expectedFullName = Path.Combine(Directory.GetCurrentDirectory(), directoryName).Replace(@"\", @"\\");
             var expectedString = @$"var directoryInfo = new DirectoryInfo
 {{
-    FullName = ""{expectedFullName}"",
-    Extension = """",
-    Name = ""{directoryName}"",
+    Attributes = FileAttributes.-1,
     CreationTime = DateTime.ParseExact(""1601-01-01T00:00:00.0000000Z"", ""O"", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
     CreationTimeUtc = DateTime.ParseExact(""1601-01-01T00:00:00.0000000Z"", ""O"", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+    Extension = """",
+    FullName = ""{expectedFullName}"",
     LastAccessTime = DateTime.ParseExact(""1601-01-01T00:00:00.0000000Z"", ""O"", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
     LastAccessTimeUtc = DateTime.ParseExact(""1601-01-01T00:00:00.0000000Z"", ""O"", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
     LastWriteTime = DateTime.ParseExact(""1601-01-01T00:00:00.0000000Z"", ""O"", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
     LastWriteTimeUtc = DateTime.ParseExact(""1601-01-01T00:00:00.0000000Z"", ""O"", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
-    Attributes = FileAttributes.-1
+    Name = ""{directoryName}""
 }};
 ";
             Assert.Equal(expectedString, actualString);

--- a/test/UnitTests/RecordReferenceTypeSpec.cs
+++ b/test/UnitTests/RecordReferenceTypeSpec.cs
@@ -1,3 +1,4 @@
+#if NET60
 using VarDump;
 using Xunit;
 
@@ -90,3 +91,4 @@ namespace UnitTests
         }
     }
 }
+#endif

--- a/test/UnitTests/TestModel/Collections.cs
+++ b/test/UnitTests/TestModel/Collections.cs
@@ -1,6 +1,19 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 
+namespace System.Runtime.CompilerServices
+{
+    using ComponentModel;
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+
 namespace UnitTests.TestModel
 {
     public class CatDictionaryOwner

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -1,19 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-	  <IsPackable>false</IsPackable>
+    <TargetFrameworks>net6.0;net461</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="7.0.1" />
+    <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/UnitTests/VariableNameSpec.cs
+++ b/test/UnitTests/VariableNameSpec.cs
@@ -44,11 +44,11 @@ namespace UnitTests
         [Fact]
         public void HashSet()
         {
-            var hashSet = new[]
+            var hashSet = new HashSet<Person>
             {
                 new Person{ Age = 32, FirstName = "Bob"},
                 new Person{ Age = 23, FirstName = "Alice"},
-            }.ToHashSet();
+            };
 
             var dumper = new CSharpDumper();
 


### PR DESCRIPTION
If dateTime has a number of ticks less than a millisecond, then update serialization: new DateTime(ticks: totalTicks, kind) => new DateTime(year, month, ..., milliseconds, kind).AddTicks(ticksLessThanMillisecond)

Add net framework 4.6.1 as a target framework to UnitTests.