### PR TITLE
Make dump output tests line-ending agnostic

### DIFF
--- a/test/VarDump.Extensions.UnitTests/VarDumpExtensionsSpec.cs
+++ b/test/VarDump.Extensions.UnitTests/VarDumpExtensionsSpec.cs
@@ -37,7 +37,7 @@ public class VarDumpExtensionsSpec
                 }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class VarDumpExtensionsSpec
                 }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -117,6 +117,6 @@ public class VarDumpExtensionsSpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/AnonymousTypeSpec.cs
+++ b/test/VarDump.UnitTests/AnonymousTypeSpec.cs
@@ -38,7 +38,7 @@ public class AnonymousTypeSpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public class AnonymousTypeSpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]

--- a/test/VarDump.UnitTests/ArraySpec.cs
+++ b/test/VarDump.UnitTests/ArraySpec.cs
@@ -26,7 +26,7 @@ public class ArraySpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class ArraySpec
                 new int[]{ 1, 2, 3 }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -75,7 +75,7 @@ public class ArraySpec
                 { 4, 5, 6 }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class ArraySpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -130,7 +130,7 @@ public class ArraySpec
             """
             var arrayOfInt = new int[0, 0];
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class ArraySpec
                 }
             }.ToImmutableArray();
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -179,7 +179,7 @@ public class ArraySpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -208,7 +208,7 @@ public class ArraySpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -233,7 +233,7 @@ public class ArraySpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -253,7 +253,7 @@ public class ArraySpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -274,7 +274,7 @@ public class ArraySpec
                 New Integer(){ 1, 2, 3 }
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -300,7 +300,7 @@ public class ArraySpec
                 { 4, 5, 6 }
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -338,7 +338,7 @@ public class ArraySpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -354,7 +354,7 @@ public class ArraySpec
             """
             Dim arrayOfInteger = New Integer(0, 0) {}
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -380,7 +380,7 @@ public class ArraySpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -406,7 +406,7 @@ public class ArraySpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -428,6 +428,6 @@ public class ArraySpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/CollectionSpec.cs
+++ b/test/VarDump.UnitTests/CollectionSpec.cs
@@ -23,7 +23,7 @@ public class CollectionSpec
                          1
                      }.AsReadOnly();
 
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class CollectionSpec
         Assert.Equal("""
                      var readOnlyCollectionOfInt = new List<int> { 1 }.AsReadOnly();
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class CollectionSpec
                          2
                      };
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class CollectionSpec
                 new List<int> { 1, 2, 3 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public class CollectionSpec
                 1
             }.AsReadOnly()
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class CollectionSpec
         Assert.Equal("""
                      Dim readOnlyCollectionOfInteger = New List(Of Integer) From { 1 }.AsReadOnly()
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -140,6 +140,6 @@ public class CollectionSpec
                 New List(Of Integer) From { 1, 2, 3 }
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/CustomCollectionSpec.cs
+++ b/test/VarDump.UnitTests/CustomCollectionSpec.cs
@@ -36,7 +36,7 @@ public class CustomCollectionSpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class CustomCollectionSpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class CustomCollectionSpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -146,7 +146,7 @@ public class CustomCollectionSpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
 }

--- a/test/VarDump.UnitTests/CustomNewLineSpec.cs
+++ b/test/VarDump.UnitTests/CustomNewLineSpec.cs
@@ -27,6 +27,6 @@ public class CustomNewLineSpec
         dumper.Dump(obj, stringWriter);
         var result = stringWriter.ToString();
 
-        Assert.Equal("var anonymousType = new \n{\n    Level1 = new \n    {\n        Level2 = new \n        {\n            Level3 = \"Level3\"\n        }\n    }\n};\n", result);
+        Assert.Equal("var anonymousType = new \n{\n    Level1 = new \n    {\n        Level2 = new \n        {\n            Level3 = \"Level3\"\n        }\n    }\n};\n", result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/DataTableSpec.cs
+++ b/test/VarDump.UnitTests/DataTableSpec.cs
@@ -67,7 +67,7 @@ public class DataTableSpec
 
         var result = dumper.Dump(products);
 
-        Assert.Equal(@"", result);
+        Assert.Equal(@"", result, ignoreLineEndingDifferences: true);
     }
 }
 

--- a/test/VarDump.UnitTests/DateTimeSpec.cs
+++ b/test/VarDump.UnitTests/DateTimeSpec.cs
@@ -30,7 +30,7 @@ public class DateTimeSpec
         var evaluatedResult = await CSharpScript.EvaluateAsync<DateTime>(result, ScriptOptions.Default.WithImports("System"));
 
         Assert.Equal(dateTime.ToUniversalTime(), evaluatedResult.ToUniversalTime());
-        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedResult, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -51,7 +51,7 @@ public class DateTimeSpec
 
         var result = dumper.Dump(dateTime);
 
-        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedResult, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class DateTimeSpec
         var evaluatedResult = await CSharpScript.EvaluateAsync<DateTimeOffset>(result, ScriptOptions.Default.WithImports("System"));
 
         Assert.Equal(dateTimeOffset, evaluatedResult);
-        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedResult, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class DateTimeSpec
 
         var result = dumper.Dump(dateTimeOffset);
 
-        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedResult, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class DateTimeSpec
 
         var result = dumper.Dump(dateTime);
 
-        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedResult, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public class DateTimeSpec
             """
             var dateTimeOffset = DateTimeOffset.ParseExact("2022-06-24T11:59:21.7961218+03:00", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -155,7 +155,7 @@ public class DateTimeSpec
                 DateOnly = DateOnly.ParseExact("2022-12-10", "O")
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class DateTimeSpec
                 TimeOnly = TimeOnly.ParseExact("22:55:33.1220000", "O")
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -204,7 +204,7 @@ public class DateTimeSpec
                 .DateOnly = DateOnly.ParseExact("2022-12-10", "O")
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -228,6 +228,6 @@ public class DateTimeSpec
                 .TimeOnly = TimeOnly.ParseExact("22:55:33.1220000", "O")
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/DictionarySpec.cs
+++ b/test/VarDump.UnitTests/DictionarySpec.cs
@@ -41,7 +41,7 @@ public class DictionarySpec
                          }
                      }
 
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class DictionarySpec
                          }
                      };
 
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class DictionarySpec
                 }
             }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -161,7 +161,7 @@ public class DictionarySpec
                          }
                      };
 
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class DictionarySpec
                          }
                      }.ToImmutableDictionary();
 
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -208,6 +208,6 @@ public class DictionarySpec
                          }
                      }.ToImmutableDictionary()
 
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/DnsEndPointSpec.cs
+++ b/test/VarDump.UnitTests/DnsEndPointSpec.cs
@@ -18,7 +18,7 @@ public class DnsEndPointSpec
             """
             var dnsEndPoint = new DnsEndPoint("google.com", 12345);
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
 
@@ -35,6 +35,6 @@ public class DnsEndPointSpec
             """
             Dim dnsEndPointValue = New DnsEndPoint("google.com", 12345)
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/EnumerableQuerySpec.cs
+++ b/test/VarDump.UnitTests/EnumerableQuerySpec.cs
@@ -22,7 +22,7 @@ public class EnumerableQuerySpec
                 6
             }.AsQueryable();
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -41,6 +41,6 @@ public class EnumerableQuerySpec
                 6
             }.AsQueryable()
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/EnumerableRangeSpec.cs
+++ b/test/VarDump.UnitTests/EnumerableRangeSpec.cs
@@ -30,7 +30,7 @@ public class EnumerableRangeSpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -55,6 +55,6 @@ public class EnumerableRangeSpec
                 }
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/FlagsSpec.cs
+++ b/test/VarDump.UnitTests/FlagsSpec.cs
@@ -14,7 +14,7 @@ public class FlagsSpec
 
         var result = dumper.Dump(flagsVar);
 
-        Assert.Equal("var testEnum = TestEnum.First | TestEnum.Third;\r\n", result);
+        Assert.Equal("var testEnum = TestEnum.First | TestEnum.Third;\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class FlagsSpec
 
         var result = dumper.Dump(flagsVar);
 
-        Assert.Equal("var testEnum = 0;\r\n", result);
+        Assert.Equal("var testEnum = 0;\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public class FlagsSpec
 
         var result = dumper.Dump(flagsVar);
 
-        Assert.Equal("var testEnum = (TestEnum)(object)-54;\r\n", result);
+        Assert.Equal("var testEnum = (TestEnum)(object)-54;\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class FlagsSpec
 
         var result = dumper.Dump(flagsVar);
 
-        Assert.Equal("Dim testEnumValue = TestEnum.Second Or TestEnum.Third\r\n", result);
+        Assert.Equal("Dim testEnumValue = TestEnum.Second Or TestEnum.Third\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class FlagsSpec
 
         var result = dumper.Dump(flagsVar);
 
-        Assert.Equal("Dim testEnumValue = 0\r\n", result);
+        Assert.Equal("Dim testEnumValue = 0\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class FlagsSpec
 
         var result = dumper.Dump(flagsVar);
 
-        Assert.Equal("Dim testEnumValue = CType(CType(-54, Object), TestEnum)\r\n", result);
+        Assert.Equal("Dim testEnumValue = CType(CType(-54, Object), TestEnum)\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Flags]

--- a/test/VarDump.UnitTests/FrozenCollectionsNet8Spec.cs
+++ b/test/VarDump.UnitTests/FrozenCollectionsNet8Spec.cs
@@ -24,7 +24,7 @@ namespace VarDump.UnitTests
                     1
                 }.ToFrozenSet();
 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -41,7 +41,7 @@ namespace VarDump.UnitTests
                     1
                 }.ToFrozenSet()
                 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace VarDump.UnitTests
                     }
                 }.ToFrozenDictionary();
                 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace VarDump.UnitTests
                     }
                 }.ToFrozenDictionary()
                 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/VarDump.UnitTests/GroupingCollectionSpec.cs
+++ b/test/VarDump.UnitTests/GroupingCollectionSpec.cs
@@ -85,7 +85,7 @@ public class GroupingCollectionSpec
                 }
             }.GroupBy(grp => grp.Key, grp => grp.Element).ToArray();
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -114,6 +114,6 @@ public class GroupingCollectionSpec
                 }
             }.GroupBy(grp => grp.Key, grp => grp.Element).Single();
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/IgnoreIndexersSpec.cs
+++ b/test/VarDump.UnitTests/IgnoreIndexersSpec.cs
@@ -13,7 +13,7 @@ public class IgnoreIndexersSpec
 
         var result = dumper.Dump(index);
 
-        Assert.Equal("var myClassWithIndexer = new MyClassWithIndexer\r\n{\r\n    Caption = \"A Default caption\"\r\n};\r\n", result);
+        Assert.Equal("var myClassWithIndexer = new MyClassWithIndexer\r\n{\r\n    Caption = \"A Default caption\"\r\n};\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public class IgnoreIndexersSpec
 
         var result = dumper.Dump(index);
 
-        Assert.Equal("Dim myClassWithIndexerValue = New MyClassWithIndexer With {\r\n    .Caption = \"A Default caption\"\r\n}\r\n", result);
+        Assert.Equal("Dim myClassWithIndexerValue = New MyClassWithIndexer With {\r\n    .Caption = \"A Default caption\"\r\n}\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     private class MyClassWithIndexer

--- a/test/VarDump.UnitTests/IgnoreReadonlyPropertiesSpec.cs
+++ b/test/VarDump.UnitTests/IgnoreReadonlyPropertiesSpec.cs
@@ -16,7 +16,7 @@ public class IgnoreReadonlyPropertiesSpec
 
         var result = dumper.Dump(subjectDescriptor);
 
-        Assert.Equal("var subjectDescriptor = new SubjectDescriptor();\r\n", result);
+        Assert.Equal("var subjectDescriptor = new SubjectDescriptor();\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class IgnoreReadonlyPropertiesSpec
                          Identifier = "identifier"
                      };
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class IgnoreReadonlyPropertiesSpec
                          Identifier = "identifier"
                      };
 
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     private struct SubjectDescriptor(string subjectType, string identifier)

--- a/test/VarDump.UnitTests/IndentStringOptionSpec.cs
+++ b/test/VarDump.UnitTests/IndentStringOptionSpec.cs
@@ -41,6 +41,6 @@ public class IndentStringOptionSpec
              }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/InheritanceSpec.cs
+++ b/test/VarDump.UnitTests/InheritanceSpec.cs
@@ -31,7 +31,7 @@ public class InheritanceSpec
                 BirthDate = DateTime.ParseExact("1964-06-19T00:00:00.0000000Z", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class InheritanceSpec
                 .BirthDate = Date.ParseExact("1964-06-19T00:00:00.0000000Z", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class InheritanceSpec
                 _derivedNumber = 20
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public class InheritanceSpec
                 ._derivedNumber = 20
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     private class Human

--- a/test/VarDump.UnitTests/IntegralTypesSpec.cs
+++ b/test/VarDump.UnitTests/IntegralTypesSpec.cs
@@ -21,7 +21,7 @@ public class IntegralTypesSpec
             """
             var ulongValue = 0b1111111111111111111111111111111111111111111111111111111111111111ul;
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class IntegralTypesSpec
             """
             var ulongValue = 18_446_744_073_709_551_615ul;
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class IntegralTypesSpec
             """
             var ulongValue = 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1110ul;
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class IntegralTypesSpec
             """
             var intValue = 0b0010_0101;
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class IntegralTypesSpec
             """
             var arrayOfInt = new int[]{ 0b100101, 0b110001, 0b1001001 };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class IntegralTypesSpec
             """
             var byteValue = 0X0F;
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class IntegralTypesSpec
             """
             var intValue = 0X0001_E240;
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public class IntegralTypesSpec
             """
             Dim uLongValue = &B1111111111111111111111111111111111111111111111111111111111111110UL
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class IntegralTypesSpec
             """
             Dim integerValue = &b0010_0101
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -176,7 +176,7 @@ public class IntegralTypesSpec
             """
             Dim byteValue = &H0F
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -193,6 +193,6 @@ public class IntegralTypesSpec
             """
             Dim integerValue = &H0001_E240
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/IpAddressSpec.cs
+++ b/test/VarDump.UnitTests/IpAddressSpec.cs
@@ -18,7 +18,7 @@ public class IpAddressSpec
             """
             var iPAddress = IPAddress.Parse("142.250.74.110");
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
 
@@ -35,6 +35,6 @@ public class IpAddressSpec
             """
             Dim iPAddressValue = IPAddress.Parse("142.250.74.110")
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/IpEndPointSpec.cs
+++ b/test/VarDump.UnitTests/IpEndPointSpec.cs
@@ -18,7 +18,7 @@ public class IpEndPointSpec
             """
             var iPEndPoint = new IPEndPoint(IPAddress.Parse("142.250.74.110"), 12345);
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
 
@@ -35,6 +35,6 @@ public class IpEndPointSpec
             """
             Dim iPEndPointValue = New IPEndPoint(IPAddress.Parse("142.250.74.110"), 12345)
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/KeyValuePairArraySpec.cs
+++ b/test/VarDump.UnitTests/KeyValuePairArraySpec.cs
@@ -26,7 +26,7 @@ public class KeyValuePairArraySpec
                 New KeyValuePair(Of Integer, String)(2, "Second")
             }
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -49,7 +49,7 @@ public class KeyValuePairArraySpec
                 New KeyValuePair(Of Integer, String)(key:=2, value:="Second")
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class KeyValuePairArraySpec
                 new KeyValuePair<int, string>(2, "Second")
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -97,6 +97,6 @@ public class KeyValuePairArraySpec
                 new KeyValuePair<int, string>(key: 2, value: "Second")
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/KnownObjectsSpec.cs
+++ b/test/VarDump.UnitTests/KnownObjectsSpec.cs
@@ -41,7 +41,7 @@ public class KnownObjectsSpec
         Assert.Equal("""
                      var uri = new Uri(uriString: "https://user:password@www.contoso.com:80/Home/Index.htm?q1=v1&q2=v2#FragmentName");
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class KnownObjectsSpec
                          ValueTuple = ("5", "6")
                      };
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
         return;
 
         static void DisableNamedArguments(DumpOptions opts)
@@ -120,7 +120,7 @@ public class KnownObjectsSpec
                     ServiceDescriptor.Scoped<IPerson, Person>()
                 };
 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class KnownObjectsSpec
             """
             Dim serviceDescriptorValue = ServiceDescriptor.Transient(Of IPerson, Person)()
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -169,7 +169,7 @@ public class KnownObjectsSpec
             """
             var concreteFormattableString = FormattableStringFactory.Create("Hello, {0}", "World");
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -194,7 +194,7 @@ public class KnownObjectsSpec
             """
             Dim concreteFormattableStringValue = FormattableStringFactory.Create("Hello, {0}", "World")
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     private class ServiceDescriptorVisitor(INextDepthVisitor nextDepthVisitor, ICodeWriter codeWriter) : IKnownObjectVisitor

--- a/test/VarDump.UnitTests/LazinessSpec.cs
+++ b/test/VarDump.UnitTests/LazinessSpec.cs
@@ -25,7 +25,7 @@ public class LazinessSpec
                 3
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
         return;
 
         static IEnumerable<int> GetItems(StringWriter writer)

--- a/test/VarDump.UnitTests/NullableSpec.cs
+++ b/test/VarDump.UnitTests/NullableSpec.cs
@@ -17,7 +17,7 @@ public class NullableSpec
             """
             var myEnum = MyEnum.TestValue;
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class NullableSpec
             """
             Dim myEnumValue = MyEnum.TestValue
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     enum MyEnum

--- a/test/VarDump.UnitTests/ObjectDescriptorMiddlewareSpec.cs
+++ b/test/VarDump.UnitTests/ObjectDescriptorMiddlewareSpec.cs
@@ -57,7 +57,7 @@ public class ObjectDescriptorMiddlewareSpec
                 ValueTuple = ("5", "6")
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class ObjectDescriptorMiddlewareSpec
             """
             var regex = new Regex("\\p{Sc}+\\s*\\d+", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class ObjectDescriptorMiddlewareSpec
             """
             var regex = new Regex(pattern: "\\p{Sc}+\\s*\\d+", options: RegexOptions.Compiled, matchTimeout: TimeSpan.FromSeconds(5));
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -145,7 +145,7 @@ public class ObjectDescriptorMiddlewareSpec
                 }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class ObjectDescriptorMiddlewareSpec
                 }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
 
         static bool IsNotCardNumber(ReflectionDescription description)
         {
@@ -231,7 +231,7 @@ public class ObjectDescriptorMiddlewareSpec
                 }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
         return;
 
         static ReflectionDescription MaskCardNumber(ReflectionDescription description)
@@ -294,7 +294,7 @@ public class ObjectDescriptorMiddlewareSpec
                 }
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -330,7 +330,7 @@ public class ObjectDescriptorMiddlewareSpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -450,7 +450,7 @@ public class ObjectDescriptorMiddlewareSpec
 
 #endif
 
-        Assert.Equal(expectedString, actualString);
+        Assert.Equal(expectedString, actualString, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -470,7 +470,7 @@ public class ObjectDescriptorMiddlewareSpec
         var expectedFullName = Path.Combine(Directory.GetCurrentDirectory(), fileName).Replace(@"\", @"\\");
         var expectedString = $"var fileInfo = new FileInfo(\"{expectedFullName}\");\r\n";
 
-        Assert.Equal(expectedString, actualString);
+        Assert.Equal(expectedString, actualString, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -487,9 +487,10 @@ public class ObjectDescriptorMiddlewareSpec
 
         var actualString = dumper.Dump(new DriveInfo(driveName));
 
-        var expectedString = "var driveInfo = new DriveInfo(\"C:\\\\\");\r\n";
+        var expectedDriveName = new DriveInfo(driveName).Name.Replace(@"\", @"\\");
+        var expectedString = $"var driveInfo = new DriveInfo(\"{expectedDriveName}\");\r\n";
 
-        Assert.Equal(expectedString, actualString);
+        Assert.Equal(expectedString, actualString, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -507,9 +508,10 @@ public class ObjectDescriptorMiddlewareSpec
 
         var actualString = dumper.Dump(new DriveInfo(driveName));
 
-        var expectedString = $"var driveInfo = new DriveInfo(driveName: \"{driveName}\\\\\");\r\n";
+        var expectedDriveName = new DriveInfo(driveName).Name.Replace(@"\", @"\\");
+        var expectedString = $"var driveInfo = new DriveInfo(driveName: \"{expectedDriveName}\");\r\n";
 
-        Assert.Equal(expectedString, actualString);
+        Assert.Equal(expectedString, actualString, ignoreLineEndingDifferences: true);
     }
 
 

--- a/test/VarDump.UnitTests/PredefinedConstantsSpec.cs
+++ b/test/VarDump.UnitTests/PredefinedConstantsSpec.cs
@@ -15,7 +15,7 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(max);
 
-        Assert.Equal("var floatValue = float.MaxValue;\r\n", result);
+        Assert.Equal("var floatValue = float.MaxValue;\r\n", result, ignoreLineEndingDifferences: true);
     }
     
     [Fact]
@@ -27,7 +27,7 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(max);
 
-        Assert.Equal("var intValue = 2147483647;\r\n", result);
+        Assert.Equal("var intValue = 2147483647;\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(max);
 
-        Assert.Equal("var dateTime = DateTime.ParseExact(\"9999-12-31T23:59:59.9999999\", \"O\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);\r\n", result);
+        Assert.Equal("var dateTime = DateTime.ParseExact(\"9999-12-31T23:59:59.9999999\", \"O\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public class PredefinedConstantsSpec
         var dumper = new CSharpDumper();
         var result = dumper.Dump(min);
 
-        Assert.Equal("var floatValue = float.MinValue;\r\n", result);
+        Assert.Equal("var floatValue = float.MinValue;\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public class PredefinedConstantsSpec
         var dumper = new CSharpDumper();
         var result = dumper.Dump(nan);
 
-        Assert.Equal("var floatValue = float.NaN;\r\n", result);
+        Assert.Equal("var floatValue = float.NaN;\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class PredefinedConstantsSpec
         var dumper = new VisualBasicDumper();
         var result = dumper.Dump(max);
 
-        Assert.Equal("Dim singleValue = Single.MaxValue\r\n", result);
+        Assert.Equal("Dim singleValue = Single.MaxValue\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(zero);
 
-        Assert.Equal("var byteValue = 0;\r\n", result);
+        Assert.Equal("var byteValue = 0;\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -96,7 +96,7 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(zero);
 
-        Assert.Equal("Dim byteValue = 0\r\n", result);
+        Assert.Equal("Dim byteValue = 0\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(zero);
 
-        Assert.Equal("var ushortValue = 0;\r\n", result);
+        Assert.Equal("var ushortValue = 0;\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(zero);
 
-        Assert.Equal("Dim uShortValue = 0US\r\n", result);
+        Assert.Equal("Dim uShortValue = 0US\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(max);
 
-        Assert.Equal("Dim integerValue = 2147483647\r\n", result);
+        Assert.Equal("Dim integerValue = 2147483647\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -144,6 +144,6 @@ public class PredefinedConstantsSpec
 
         var result = dumper.Dump(max);
 
-        Assert.Equal("Dim dateValue = Date.ParseExact(\"9999-12-31T23:59:59.9999999\", \"O\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)\r\n", result);
+        Assert.Equal("Dim dateValue = Date.ParseExact(\"9999-12-31T23:59:59.9999999\", \"O\", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind)\r\n", result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/PrimitiveTypesSpec.cs
+++ b/test/VarDump.UnitTests/PrimitiveTypesSpec.cs
@@ -13,7 +13,7 @@ namespace VarDump.UnitTests
 
             var result = dumper.Dump(value);
 
-            Assert.Equal("var decimalValue = 0.00000m;\r\n", result);
+            Assert.Equal("var decimalValue = 0.00000m;\r\n", result, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace VarDump.UnitTests
 
             var result = dumper.Dump(value);
 
-            Assert.Equal("Dim decimalValue = 0.00000D\r\n", result);
+            Assert.Equal("Dim decimalValue = 0.00000D\r\n", result, ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/VarDump.UnitTests/ReadonlyCollectionInitializerSpec.cs
+++ b/test/VarDump.UnitTests/ReadonlyCollectionInitializerSpec.cs
@@ -32,7 +32,7 @@ public class ReadonlyCollectionInitializerSpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact(Skip = "Not implemented yet")]
@@ -62,6 +62,6 @@ public class ReadonlyCollectionInitializerSpec
                 }
             };
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/RecordReferenceTypeSpec.cs
+++ b/test/VarDump.UnitTests/RecordReferenceTypeSpec.cs
@@ -14,7 +14,7 @@ public class RecordReferenceTypeSpec
 
         var result = dumper.Dump(person);
 
-        Assert.Equal("var person = new Person(\"Boris\", \"Johnson\");\r\n", result);
+        Assert.Equal("var person = new Person(\"Boris\", \"Johnson\");\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class RecordReferenceTypeSpec
 
         var result = dumper.Dump(person);
 
-        Assert.Equal("Dim personValue = New Person(\"Boris\", \"Johnson\")\r\n", result);
+        Assert.Equal("Dim personValue = New Person(\"Boris\", \"Johnson\")\r\n", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -48,7 +48,7 @@ public class RecordReferenceTypeSpec
     FirstName = ""Boris"",
     LastName = ""Johnson""
 };
-", result);
+", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public class RecordReferenceTypeSpec
     .FirstName = ""Boris"",
     .LastName = ""Johnson""
 }
-", result);
+", result, ignoreLineEndingDifferences: true);
     }
 
     private record Person(string FirstName, string LastName)

--- a/test/VarDump.UnitTests/RegexSpec.cs
+++ b/test/VarDump.UnitTests/RegexSpec.cs
@@ -20,7 +20,7 @@ namespace VarDump.UnitTests
                 """
                 var regex = new Regex("\\p{Sc}+\\s*\\d+", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace VarDump.UnitTests
                 """
                 var regex = new Regex(pattern: "\\p{Sc}+\\s*\\d+", options: RegexOptions.Compiled, matchTimeout: TimeSpan.FromSeconds(5));
                 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace VarDump.UnitTests
                 """
                 Dim regexValue = New Regex("\p{Sc}+\s*\d+", RegexOptions.Compiled, TimeSpan.FromSeconds(5))
                 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace VarDump.UnitTests
                 """
                 Dim regexValue = New Regex(pattern:="\p{Sc}+\s*\d+", options:=RegexOptions.Compiled, matchTimeout:=TimeSpan.FromSeconds(5))
                 
-                """, result);
+                """, result, ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/test/VarDump.UnitTests/TooManyItemsCollectionSpec.cs
+++ b/test/VarDump.UnitTests/TooManyItemsCollectionSpec.cs
@@ -25,7 +25,7 @@ public class TooManyItemsCollectionSpec
                          // Too many items (> 2). Consider increasing the MaxCollectionSize option.
                      }.AsReadOnly();
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class TooManyItemsCollectionSpec
                          // Too many items (> 2). Consider increasing the MaxCollectionSize option.
                      };
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -107,7 +107,7 @@ public class TooManyItemsCollectionSpec
                          // Too many items (> 2). Consider increasing the MaxCollectionSize option.
                      }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class TooManyItemsCollectionSpec
                 // Too many items (> 2). Consider increasing the MaxCollectionSize option.
             }.GroupBy(grp => grp.Key, grp => grp.Element).ToArray();
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -169,6 +169,6 @@ public class TooManyItemsCollectionSpec
                          'Too many items (> 2). Consider increasing the MaxCollectionSize option.
                      }.AsReadOnly()
                      
-                     """, result);
+                     """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/TupleArraySpec.cs
+++ b/test/VarDump.UnitTests/TupleArraySpec.cs
@@ -26,7 +26,7 @@ public class TupleArraySpec
                 New Tuple(Of Integer, String)(2, "Second")
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -49,7 +49,7 @@ public class TupleArraySpec
                 New Tuple(Of Integer, String)(item1:=2, item2:="Second")
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class TupleArraySpec
                 new Tuple<int, string>(2, "Second")
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -97,6 +97,6 @@ public class TupleArraySpec
                 new Tuple<int, string>(item1: 2, item2: "Second")
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/UriSpec.cs
+++ b/test/VarDump.UnitTests/UriSpec.cs
@@ -17,7 +17,7 @@ public class UriSpec
             """
             var uri = new Uri("https://user:password@www.contoso.com:80/Home/Index.htm?q1=v1&q2=v2#FragmentName");
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -33,7 +33,7 @@ public class UriSpec
             """
             Dim uriValue = New Uri("https://user:password@www.contoso.com:80/Home/Index.htm?q1=v1&q2=v2#FragmentName")
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -51,7 +51,7 @@ public class UriSpec
             """
             var uri = new Uri("index.htm?date=today", UriKind.Relative);
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -69,6 +69,6 @@ public class UriSpec
             """
             Dim uriValue = New Uri("index.htm?date=today", UriKind.Relative)
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/ValueTupleArraySpec.cs
+++ b/test/VarDump.UnitTests/ValueTupleArraySpec.cs
@@ -26,7 +26,7 @@ public class ValueTupleArraySpec
                 (2, "Second")
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -49,7 +49,7 @@ public class ValueTupleArraySpec
                 (item1:=2, item2:="Second")
             }
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public class ValueTupleArraySpec
                 (2, "Second")
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -97,6 +97,6 @@ public class ValueTupleArraySpec
                 (item1: 2, item2: "Second")
             };
             
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/VariableNameSpec.cs
+++ b/test/VarDump.UnitTests/VariableNameSpec.cs
@@ -80,7 +80,7 @@ public class VariableNameSpec
 
         var result = dumper.Dump(stringValue);
 
-        Assert.Equal("\"Test string value\"", result);
+        Assert.Equal("\"Test string value\"", result, ignoreLineEndingDifferences: true);
     }
 
     [Fact]
@@ -95,6 +95,6 @@ public class VariableNameSpec
 
         var result = dumper.Dump(stringValue);
 
-        Assert.Equal("\"Test string value\"", result);
+        Assert.Equal("\"Test string value\"", result, ignoreLineEndingDifferences: true);
     }
 }

--- a/test/VarDump.UnitTests/VersionSpec.cs
+++ b/test/VarDump.UnitTests/VersionSpec.cs
@@ -18,7 +18,7 @@ public class VersionSpec
             """
             var version = new Version("1.2.3.4");
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 
 
@@ -35,6 +35,6 @@ public class VersionSpec
             """
             Dim versionValue = New Version("1.2.3.4")
 
-            """, result);
+            """, result, ignoreLineEndingDifferences: true);
     }
 }


### PR DESCRIPTION
## Summary
- Use xUnit's `ignoreLineEndingDifferences: true` for dump output string assertions
- Make DriveInfo middleware expectations derive the platform-specific drive name
- Keeps production output unchanged while allowing tests to pass on Linux and Windows line endings

## Verification
- `dotnet build VarDump.sln --configuration Release --no-restore`
- `dotnet test test/VarDump.UnitTests/VarDump.UnitTests.csproj --configuration Release --no-build --framework net6.0`
- `dotnet test test/VarDump.UnitTests/VarDump.UnitTests.csproj --configuration Release --no-build --framework net9.0`
- `dotnet test test/VarDump.Extensions.UnitTests/VarDump.Extensions.UnitTests.csproj --configuration Release --no-build --framework net6.0`
- `dotnet test test/VarDump.Extensions.UnitTests/VarDump.Extensions.UnitTests.csproj --configuration Release --no-build --framework net9.0`