### PR TITLE
Performance

### DIFF
--- a/perf/VarDump.Performance/VarDump.Performance.csproj
+++ b/perf/VarDump.Performance/VarDump.Performance.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ObjectDumper.NET" Version="4.3.2" />
   </ItemGroup>
 

--- a/src/VarDump/VarDump.csproj
+++ b/src/VarDump/VarDump.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>VarDump</AssemblyName>
-    <AssemblyVersion>2.0.3.0</AssemblyVersion>
-    <FileVersion>2.0.3.0</FileVersion>
+    <AssemblyVersion>2.0.4.0</AssemblyVersion>
+    <FileVersion>2.0.4.0</FileVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2023 - $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>VarDump</Title>
-    <Version>2.0.3.0</Version>
+    <Version>2.0.4.0</Version>
     <Description>VarDump is a utility for serialization runtime objects to C# and Visual Basic string.</Description>
     <PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -18,12 +18,12 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>dump;dumpobject;c#;visulabasic;debug</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-	<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	<EmbedUntrackedSources>true</EmbedUntrackedSources>
-	<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-	<Authors>Yevhen Cherkes</Authors>
-	<IncludeSymbols>true</IncludeSymbols>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Authors>Yevhen Cherkes</Authors>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1570;CS1591</NoWarn>
   </PropertyGroup>

--- a/src/VarDump/Visitor/DescriptionBasedVisitor.cs
+++ b/src/VarDump/Visitor/DescriptionBasedVisitor.cs
@@ -37,13 +37,11 @@ internal sealed class DescriptionBasedVisitor : ISpecificVisitor
 
     public void Visit(object o, Type objectType, VisitContext context)
     {
-        if (context.IsVisited(o))
+        if (!context.TryAddVisited(o))
         {
             _codeWriter.WriteCircularReferenceDetected();
             return;
         }
-
-        context.PushVisited(o);
 
         try
         {
@@ -53,7 +51,7 @@ internal sealed class DescriptionBasedVisitor : ISpecificVisitor
         }
         finally
         {
-            context.PopVisited();
+            context.RemoveVisited(o);
         }
     }
 }

--- a/src/VarDump/Visitor/KnownObjects/CollectionVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/CollectionVisitor.cs
@@ -44,17 +44,16 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
     public void Visit(object obj, Type collectionType, VisitContext context)
     {
-        IEnumerable collection = (IEnumerable)obj;
-        if (context.IsVisited(collection))
+        if (!context.TryAddVisited(obj))
         {
             _codeWriter.WriteCircularReferenceDetected();
             return;
         }
 
-        context.PushVisited(collection);
-
         try
         {
+            IEnumerable collection = (IEnumerable)obj;
+
             var elementType = ReflectionUtils.GetInnerElementType(collectionType);
 
             if (elementType.IsGrouping())
@@ -73,7 +72,7 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         }
         finally
         {
-            context.PopVisited();
+            context.RemoveVisited(obj);
         }
     }
 
@@ -202,8 +201,7 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
             var createAction = ResolveCollectionCreateAction(typeInfo, items, singleLine);
 
-            _codeWriter.WriteMethodInvoke(() => _codeWriter.WriteMethodReference(() =>
-               createAction(), "AsReadOnly"), []);
+            _codeWriter.WriteMethodInvoke(() => _codeWriter.WriteMethodReference(createAction, "AsReadOnly"), []);
 
             return;
         }

--- a/src/VarDump/Visitor/KnownObjects/DictionaryVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/DictionaryVisitor.cs
@@ -43,13 +43,11 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
     public void Visit(object obj, Type objectType, VisitContext context)
     {
         IDictionary dict = (IDictionary)obj;
-        if (context.IsVisited(dict))
+        if (!context.TryAddVisited(dict))
         {
             _codeWriter.WriteCircularReferenceDetected();
             return;
         }
-
-        context.PushVisited(dict);
 
         try
         {
@@ -67,7 +65,7 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
         }
         finally
         {
-            context.PopVisited();
+            context.RemoveVisited(dict);
         }
     }
 

--- a/src/VarDump/Visitor/KnownObjects/TupleVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/TupleVisitor.cs
@@ -23,13 +23,11 @@ internal sealed class TupleVisitor(INextDepthVisitor nextDepthVisitor, ICodeWrit
 
     public void Visit(object o, Type objectType, VisitContext context)
     {
-        if (context.IsVisited(o))
+        if (!context.TryAddVisited(o))
         {
             codeWriter.WriteCircularReferenceDetected();
             return;
         }
-
-        context.PushVisited(o);
 
         try
         {
@@ -43,7 +41,7 @@ internal sealed class TupleVisitor(INextDepthVisitor nextDepthVisitor, ICodeWrit
         }
         finally
         {
-            context.PopVisited();
+            context.RemoveVisited(o);
         }
     }
 }

--- a/src/VarDump/Visitor/ObjectVisitor.cs
+++ b/src/VarDump/Visitor/ObjectVisitor.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using VarDump.CodeDom.Compiler;
 using VarDump.Collections;
 using VarDump.Extensions;
@@ -14,21 +12,17 @@ internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor
     private readonly IKnownObjectsCollection _knownObjects;
     private readonly int _maxDepth;
     private readonly ISpecificVisitor _descriptionBasedVisitor;
-    private readonly IKnownObjectVisitor _nullValueVisitor;
-    private readonly Dictionary<Type, ISpecificVisitor> _typeDispatch;
 
     public ObjectVisitor(DumpOptions options, ICodeWriter codeWriter)
     {
         _codeWriter = codeWriter;
         _maxDepth = options.MaxDepth;
 
-        _typeDispatch = new Dictionary<Type, ISpecificVisitor>();
-        _nullValueVisitor = new PrimitiveVisitor(codeWriter, options);
         _descriptionBasedVisitor = new DescriptionBasedVisitor(codeWriter, this, options);
 
         _knownObjects = new KnownObjectsCollection
         {
-            _nullValueVisitor,
+            new PrimitiveVisitor(codeWriter, options),
             new TimeSpanVisitor(codeWriter, options),
             new DateTimeVisitor(codeWriter, options),
             new DateTimeOffsetVisitor(this, codeWriter, options),
@@ -74,36 +68,12 @@ internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor
         {
             context.CurrentDepth++;
 
-            
-            if (@object == null)
-            {
-                _nullValueVisitor.Visit(null, null, context);
-            }
-            else
-            {
-                var objectType = @object.GetType();
+            var objectType = @object?.GetType();
 
-                if (_typeDispatch.TryGetValue(objectType, out var cachedVisitor))
-                {
-                    cachedVisitor.Visit(@object, objectType, context);
-                    return;
-                }
+            var specificVisitor = _knownObjects.Values.FirstOrDefault(v => v.IsSuitableFor(@object, objectType))
+                                  ?? _descriptionBasedVisitor;
 
-                foreach (var visitor in _knownObjects.Values)
-                {
-                    if (!visitor.IsSuitableFor(@object, objectType)) continue;
-
-                    _typeDispatch[objectType] = visitor;
-
-                    visitor.Visit(@object, objectType, context);
-                    return;
-                }
-
-                _typeDispatch[objectType] = _descriptionBasedVisitor;
-
-                _descriptionBasedVisitor.Visit(@object, objectType, context);
-            }
-            
+            specificVisitor.Visit(@object, objectType, context);
         }
         finally
         {

--- a/src/VarDump/Visitor/ObjectVisitor.cs
+++ b/src/VarDump/Visitor/ObjectVisitor.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using VarDump.CodeDom.Compiler;
 using VarDump.Collections;
 using VarDump.Extensions;
@@ -12,17 +14,21 @@ internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor
     private readonly IKnownObjectsCollection _knownObjects;
     private readonly int _maxDepth;
     private readonly ISpecificVisitor _descriptionBasedVisitor;
+    private readonly IKnownObjectVisitor _nullValueVisitor;
+    private readonly Dictionary<Type, ISpecificVisitor> _typeDispatch;
 
     public ObjectVisitor(DumpOptions options, ICodeWriter codeWriter)
     {
         _codeWriter = codeWriter;
         _maxDepth = options.MaxDepth;
 
+        _typeDispatch = new Dictionary<Type, ISpecificVisitor>();
+        _nullValueVisitor = new PrimitiveVisitor(codeWriter, options);
         _descriptionBasedVisitor = new DescriptionBasedVisitor(codeWriter, this, options);
 
         _knownObjects = new KnownObjectsCollection
         {
-            new PrimitiveVisitor(codeWriter, options),
+            _nullValueVisitor,
             new TimeSpanVisitor(codeWriter, options),
             new DateTimeVisitor(codeWriter, options),
             new DateTimeOffsetVisitor(this, codeWriter, options),
@@ -68,12 +74,36 @@ internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor
         {
             context.CurrentDepth++;
 
-            var objectType = @object?.GetType();
+            
+            if (@object == null)
+            {
+                _nullValueVisitor.Visit(null, null, context);
+            }
+            else
+            {
+                var objectType = @object.GetType();
 
-            var specificVisitor = _knownObjects.Values.FirstOrDefault(v => v.IsSuitableFor(@object, objectType))
-                                  ?? _descriptionBasedVisitor;
+                if (_typeDispatch.TryGetValue(objectType, out var cachedVisitor))
+                {
+                    cachedVisitor.Visit(@object, objectType, context);
+                    return;
+                }
 
-            specificVisitor.Visit(@object, objectType, context);
+                foreach (var visitor in _knownObjects.Values)
+                {
+                    if (!visitor.IsSuitableFor(@object, objectType)) continue;
+
+                    _typeDispatch[objectType] = visitor;
+
+                    visitor.Visit(@object, objectType, context);
+                    return;
+                }
+
+                _typeDispatch[objectType] = _descriptionBasedVisitor;
+
+                _descriptionBasedVisitor.Visit(@object, objectType, context);
+            }
+            
         }
         finally
         {

--- a/src/VarDump/Visitor/VisitContext.cs
+++ b/src/VarDump/Visitor/VisitContext.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using VarDump.Collections;
 
 namespace VarDump.Visitor;
@@ -7,23 +6,22 @@ namespace VarDump.Visitor;
 public sealed class VisitContext(int maxDepth)
 {
     private static readonly IEqualityComparer<object> IdentityComparer = new ObjectIdentityComparer();
-    private readonly Stack<object> _visitedObjects = new();
+    private readonly HashSet<object> _visitedObjects = new(IdentityComparer);
 
     public int CurrentDepth { get; set; }
 
-    public void PushVisited(object value)
+    public bool TryAddVisited(object value)
     {
-        _visitedObjects.Push(value);
+        return value is null
+               || value.GetType().IsValueType
+               || _visitedObjects.Add(value);
     }
 
-    public void PopVisited()
+    public void RemoveVisited(object value)
     {
-        _visitedObjects.Pop();
-    }
+        if(value is null || value.GetType().IsValueType) return;
 
-    public bool IsVisited(object value)
-    {
-        return value != null && _visitedObjects.Contains(value, IdentityComparer);
+        _visitedObjects.Remove(value);
     }
 
     public bool IsMaxDepth()

--- a/test/VarDump.UnitTests/CircularReferenceSpec.cs
+++ b/test/VarDump.UnitTests/CircularReferenceSpec.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections;
 using VarDump.Visitor;
 using Xunit;
 
@@ -5,6 +7,113 @@ namespace VarDump.UnitTests;
 
 public class CircularReferenceSpec
 {
+    [Fact]
+    public void DumpSelfReferencingObjectCSharp_ShouldWriteCircularReferenceComment()
+    {
+        var node = new Node { Name = "root" };
+        node.Next = node;
+
+        var dumper = new CSharpDumper();
+
+        var result = dumper.Dump(node);
+
+        Assert.Contains("Circular reference detected", result);
+    }
+
+    [Fact]
+    public void DumpSharedReferenceObjectCSharp_ShouldNotTreatSiblingReuseAsCircularReference()
+    {
+        var shared = new Node { Name = "shared" };
+        var root = new Root
+        {
+            First = shared,
+            Second = shared
+        };
+
+        var dumper = new CSharpDumper();
+
+        var result = dumper.Dump(root);
+
+        Assert.DoesNotContain("Circular reference detected", result);
+        Assert.Equal(2, CountOccurrences(result, "Name = \"shared\""));
+    }
+
+    [Fact]
+    public void DumpCircularCollectionCSharp_ShouldWriteCircularReferenceComment()
+    {
+        var list = new ArrayList();
+        list.Add(list);
+
+        var dumper = new CSharpDumper();
+
+        var result = dumper.Dump(list);
+
+        Assert.Contains("Circular reference detected", result);
+    }
+
+    [Fact]
+    public void DumpCircularDictionaryCSharp_ShouldWriteCircularReferenceComment()
+    {
+        var dictionary = new Hashtable();
+        dictionary["self"] = dictionary;
+
+        var dumper = new CSharpDumper();
+
+        var result = dumper.Dump(dictionary);
+
+        Assert.Contains("Circular reference detected", result);
+    }
+
+    [Fact]
+    public void DumpTupleContainingCircularReferenceCSharp_ShouldWriteCircularReferenceComment()
+    {
+        var items = new ArrayList();
+        var tuple = new Tuple<ArrayList>(items);
+        items.Add(tuple);
+
+        var dumper = new CSharpDumper();
+
+        var result = dumper.Dump(tuple);
+
+        Assert.Contains("Circular reference detected", result);
+    }
+
+    [Fact]
+    public void DumpDeepObjectCSharp_ShouldStillRespectMaxDepth()
+    {
+        var node = new Node
+        {
+            Name = "root",
+            Next = new Node { Name = "child" }
+        };
+
+        var dumper = new CSharpDumper(new DumpOptions { MaxDepth = 1 });
+
+        var result = dumper.Dump(node);
+
+        Assert.Contains("Max depth", result);
+        Assert.DoesNotContain("Circular reference detected", result);
+    }
+
+    private static int CountOccurrences(string value, string search)
+    {
+        return value.Split([search], StringSplitOptions.None).Length - 1;
+    }
+
+    private sealed class Node
+    {
+        public string Name { get; set; }
+
+        public Node Next { get; set; }
+    }
+
+    private sealed class Root
+    {
+        public Node First { get; set; }
+
+        public Node Second { get; set; }
+    }
+
     [Fact]
     public void DumpAssemblyCSharp_ShouldNotThrowStackOverflowOrOutOfMemoryException()
     {

--- a/test/VarDump.UnitTests/VarDump.UnitTests.csproj
+++ b/test/VarDump.UnitTests/VarDump.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net10.0;net462</TargetFrameworks>
+    <TargetFrameworks>net10.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
### Improve circular-reference handling.

 Refactors VisitContext to use an identity-based HashSet for visited-object tracking and updates visitor consumers to use TryAddVisited / RemoveVisited. Adds regression tests for circular references, shared references, circular
 collections/dictionaries, tuple cycles, and max-depth behavior.

 Risk Analysis:
 Medium risk. Circular-reference semantics changed from stack scanning to set membership, which should improve correctness for active traversal paths but may affect edge
 cases. VisitContext API changed, so external callers using PushVisited, PopVisited, or IsVisited would break. 
