### PR TITLE
Streaming writer refactor

### DIFF
--- a/perf/VarDump.Performance/Program.cs
+++ b/perf/VarDump.Performance/Program.cs
@@ -1,6 +1,6 @@
 ﻿using BenchmarkDotNet.Running;
 
-BenchmarkRunner.Run(typeof(Program).Assembly);
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
 //using VarDump;
 

--- a/perf/VarDump.Performance/Program.cs
+++ b/perf/VarDump.Performance/Program.cs
@@ -1,6 +1,6 @@
 ﻿using BenchmarkDotNet.Running;
 
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+BenchmarkRunner.Run(typeof(Program).Assembly);
 
 //using VarDump;
 

--- a/src/VarDump.Extensions/VarDump.Extensions.csproj
+++ b/src/VarDump.Extensions/VarDump.Extensions.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="VarDump" Version="2.0.5" />
+    <PackageReference Include="VarDump" Version="2.0.6" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/VarDump.Extensions/VarDump.Extensions.csproj
+++ b/src/VarDump.Extensions/VarDump.Extensions.csproj
@@ -6,13 +6,13 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>VarDump.Extensions</AssemblyName>
-    <AssemblyVersion>2.0.5.0</AssemblyVersion>
-    <FileVersion>2.0.5.0</FileVersion>
+    <AssemblyVersion>2.0.6.0</AssemblyVersion>
+    <FileVersion>2.0.6.0</FileVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>VarDump.Extensions</Title>
-    <Version>2.0.5.0</Version>
+    <Version>2.0.6.0</Version>
     <Description>Extension methods to simplify usage of the VarDump library.</Description>
     <PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -42,7 +42,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.303" />
   </ItemGroup>
 
 </Project>

--- a/src/VarDump.Extensions/VarDump.Extensions.csproj
+++ b/src/VarDump.Extensions/VarDump.Extensions.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="VarDump" Version="2.0.4" />
+    <PackageReference Include="VarDump" Version="2.0.5" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/VarDump.Extensions/VarDump.Extensions.csproj
+++ b/src/VarDump.Extensions/VarDump.Extensions.csproj
@@ -6,13 +6,13 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>VarDump.Extensions</AssemblyName>
-    <AssemblyVersion>1.0.5.18</AssemblyVersion>
-    <FileVersion>1.0.5.18</FileVersion>
+    <AssemblyVersion>2.0.5.0</AssemblyVersion>
+    <FileVersion>2.0.5.0</FileVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>VarDump.Extensions</Title>
-    <Version>1.0.5.18</Version>
+    <Version>2.0.5.0</Version>
     <Description>Extension methods to simplify usage of the VarDump library.</Description>
     <PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -20,11 +20,11 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>dump;dumpobject;c#;visulabasic;debug</PackageTags>
     <NeutralLanguage>en</NeutralLanguage>
-	<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	<EmbedUntrackedSources>true</EmbedUntrackedSources>
-	<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-	<Authors>YevhenCherkes</Authors>
-	<IncludeSymbols>true</IncludeSymbols>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Authors>YevhenCherkes</Authors>
+    <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>CS1570;CS1591</NoWarn>
@@ -38,7 +38,11 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="VarDump" Version="1.0.5.18" />
+    <PackageReference Include="VarDump" Version="2.0.4" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
   </ItemGroup>
 
 </Project>

--- a/src/VarDump/CodeDom/CSharp/CSharpCodeWriter.cs
+++ b/src/VarDump/CodeDom/CSharp/CSharpCodeWriter.cs
@@ -260,7 +260,7 @@ internal sealed class CSharpCodeWriter : ICodeWriter
         }
     }
 
-    private void ContinueOnNewLine(string st) => _output.WriteLine(st);
+    private void ContinueOnNewLine(char ch) => _output.WriteLine(ch);
 
     private void OutputIdentifier(string ident) => _output.Write(CSharpHelpers.CreateEscapedIdentifier(ident));
 
@@ -872,7 +872,7 @@ internal sealed class CSharpCodeWriter : ICodeWriter
             if (first)
                 first = false;
             else if (newlineBetweenItems)
-                ContinueOnNewLine(",");
+                ContinueOnNewLine(',');
             else
                 _output.Write(", ");
 
@@ -894,7 +894,7 @@ internal sealed class CSharpCodeWriter : ICodeWriter
             else
             {
                 if (newlineBetweenItems)
-                    ContinueOnNewLine(",");
+                    ContinueOnNewLine(',');
                 else
                     _output.Write(", ");
             }

--- a/src/VarDump/CodeDom/CSharp/CSharpCodeWriter.cs
+++ b/src/VarDump/CodeDom/CSharp/CSharpCodeWriter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -345,6 +346,29 @@ internal sealed class CSharpCodeWriter : ICodeWriter
         }
     }
 
+    public void WriteCollectionExpressionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false)
+    {
+        var enumerator = items.GetEnumerator();
+        using var enumeratorDisposable = enumerator as IDisposable;
+        var hasItems = enumerator.MoveNext();
+        if (singleLine)
+        {
+            _output.Write("[");
+            if (hasItems)
+                OutputItems(enumerator, writeItem, newlineBetweenItems: false);
+            _output.Write("]");
+        }
+        else
+        {
+            _output.WriteLine();
+            _output.WriteLine("[");
+            if (hasItems)
+                OutputItems(enumerator, writeItem, newlineBetweenItems: true);
+            _output.WriteLine();
+            _output.Write("]");
+        }
+    }
+
     public void WriteCast(CodeTypeInfo typeInfo, Action action)
     {
         _output.Write("(");
@@ -358,6 +382,12 @@ internal sealed class CSharpCodeWriter : ICodeWriter
         left();
         _output.Write(" = ");
         right();
+    }
+
+    public void WriteMemberAssignmentStart(string memberName)
+    {
+        WritePropertyReference(memberName, null);
+        _output.Write(" = ");
     }
 
     public void WriteDefaultValue(CodeTypeInfo typeInfo)
@@ -830,6 +860,104 @@ internal sealed class CSharpCodeWriter : ICodeWriter
         _output.Write(')');
     }
 
+    public void WriteArrayCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem, bool singleLine, int size = 0)
+    {
+        _output.Write("new ");
+        var enumerator = items.GetEnumerator();
+        using var enumeratorDisposable = enumerator as IDisposable;
+
+        if (enumerator.MoveNext())
+        {
+            if (singleLine)
+            {
+                OutputType(typeInfo);
+                _output.Write("{ ");
+                OutputItems(enumerator, writeItem, newlineBetweenItems: false);
+                _output.Write(" }");
+            }
+            else
+            {
+                OutputType(typeInfo);
+                _output.WriteLine("");
+                _output.WriteLine("{");
+                OutputItems(enumerator, writeItem, newlineBetweenItems: true);
+                _output.WriteLine();
+                _output.Write("}");
+            }
+        }
+        else
+        {
+            BaseTypeOutput(typeInfo);
+            _output.Write('[');
+            _output.Write(size);
+            for (int i = 0; i < typeInfo.ArrayRank - 1; i++)
+            {
+                _output.Write(", ");
+                _output.Write(size);
+            }
+            _output.Write(']');
+        }
+    }
+
+    public void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IDictionary items, Action<object> writeKey,
+        Action<object> writeValue)
+    {
+        _output.Write("new ");
+        OutputType(typeInfo);
+
+        var enumerator = items.GetEnumerator();
+        using var enumeratorDisposable = enumerator as IDisposable;
+        if (!enumerator.MoveNext())
+        {
+            _output.Write("()");
+            return;
+        }
+
+        _output.WriteLine();
+        _output.WriteLine('{');
+        OutputDictionaryItems(enumerator, writeKey, writeValue);
+        _output.WriteLine();
+        _output.Write('}');
+    }
+
+    public void WriteObjectCreateAndInitializeItems(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions,
+        IEnumerable initializers, Action<object> writeInitializer, bool singleLine = false)
+    {
+        _output.Write("new ");
+        OutputType(typeInfo);
+        using var parametersEnumerator = parametersActions.GetEnumerator();
+        var initializerEnumerator = initializers.GetEnumerator();
+        using var initializerEnumeratorDisposable = initializerEnumerator as IDisposable;
+        var parametersExist = parametersEnumerator.MoveNext();
+        var initializerExists = initializerEnumerator.MoveNext();
+
+        if (parametersExist || !initializerExists)
+        {
+            _output.Write('(');
+            if (parametersExist)
+                OutputActions(parametersEnumerator, newlineBetweenItems: false);
+            _output.Write(')');
+        }
+
+        if (!initializerExists)
+            return;
+
+        if (singleLine)
+        {
+            _output.Write(" { ");
+            OutputItems(initializerEnumerator, writeInitializer, newlineBetweenItems: false);
+            _output.Write(" }");
+        }
+        else
+        {
+            _output.WriteLine();
+            _output.WriteLine('{');
+            OutputItems(initializerEnumerator, writeInitializer, newlineBetweenItems: true);
+            _output.WriteLine();
+            _output.Write("}");
+        }
+    }
+
     private void OutputActions(IEnumerable<Action> actions, bool newlineBetweenItems)
     {
         using var enumerator = actions.GetEnumerator();
@@ -837,6 +965,47 @@ internal sealed class CSharpCodeWriter : ICodeWriter
         {
             OutputActions(enumerator, newlineBetweenItems);
         }
+    }
+
+    private void OutputItems(IEnumerator items, Action<object> writeItem, bool newlineBetweenItems)
+    {
+        bool first = true;
+        Indent++;
+        do
+        {
+            if (first)
+                first = false;
+            else if (newlineBetweenItems)
+                ContinueOnNewLine(",");
+            else
+                _output.Write(", ");
+
+            writeItem(items.Current);
+        } while (items.MoveNext());
+        Indent--;
+    }
+
+    private void OutputDictionaryItems(IDictionaryEnumerator items, Action<object> writeKey, Action<object> writeValue)
+    {
+        var first = true;
+        Indent++;
+        do
+        {
+            if (first)
+                first = false;
+            else
+                ContinueOnNewLine(",");
+
+            _output.WriteLine('{');
+            Indent++;
+            writeKey(items.Key);
+            ContinueOnNewLine(",");
+            writeValue(items.Value);
+            Indent--;
+            _output.WriteLine();
+            _output.Write('}');
+        } while (items.MoveNext());
+        Indent--;
     }
 
     private void OutputActions(IEnumerator<Action> actions, bool newlineBetweenItems)

--- a/src/VarDump/CodeDom/CSharp/CSharpCodeWriter.cs
+++ b/src/VarDump/CodeDom/CSharp/CSharpCodeWriter.cs
@@ -264,85 +264,27 @@ internal sealed class CSharpCodeWriter : ICodeWriter
 
     private void OutputIdentifier(string ident) => _output.Write(CSharpHelpers.CreateEscapedIdentifier(ident));
 
-    public void WriteArrayCreate(CodeTypeInfo typeInfo, IEnumerable<Action> initializers, bool singleLine, int size = 0)
+    public void WriteArrayDimensionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false)
     {
-        _output.Write("new ");
-
-        using var initializersEnumerator = initializers.GetEnumerator();
-
-        if (initializersEnumerator.MoveNext())
-        {
-            if (singleLine)
-            {
-                OutputType(typeInfo);
-                _output.Write("{ ");
-                OutputActions(initializersEnumerator, newlineBetweenItems: false);
-                _output.Write(" }");
-            }
-            else
-            {
-                OutputType(typeInfo);
-                _output.WriteLine("");
-                _output.WriteLine("{");
-                OutputActions(initializersEnumerator, newlineBetweenItems: true);
-                _output.WriteLine();
-                _output.Write("}");
-            }
-        }
-        else
-        {
-            BaseTypeOutput(typeInfo);
-
-            _output.Write('[');
-            _output.Write(size);
-            for (int i = 0; i < typeInfo.ArrayRank - 1; i++)
-            {
-                _output.Write(", ");
-                _output.Write(size);
-            }
-            _output.Write(']');
-
-            int nestedArrayDepth = typeInfo.NestedArrayDepth;
-            for (int i = 0; i < nestedArrayDepth - 1; i++)
-            {
-                _output.Write("[]");
-            }
-        }
-    }
-
-    public void WriteArrayDimension(IEnumerable<Action> initializers, bool singleLine = false)
-    {
+        var enumerator = items.GetEnumerator();
+        using var enumeratorDisposable = enumerator as IDisposable;
+        var hasItems = enumerator.MoveNext();
+        
         if (singleLine)
         {
             _output.Write("{ ");
-            OutputActions(initializers, newlineBetweenItems: false);
+            if (hasItems)
+                OutputItems(enumerator, writeItem, newlineBetweenItems: false);
             _output.Write(" }");
         }
         else
         {
             _output.Write("{");
             _output.WriteLine();
-            OutputActions(initializers, newlineBetweenItems: true);
+            if (hasItems)
+                OutputItems(enumerator, writeItem, newlineBetweenItems: true);
             _output.WriteLine();
             _output.Write("}");
-        }
-    }
-
-    public void WriteCollectionExpression(IEnumerable<Action> initializers, bool singleLine = false)
-    {
-        if (singleLine)
-        {
-            _output.Write("[");
-            OutputActions(initializers, newlineBetweenItems: false);
-            _output.Write("]");
-        }
-        else
-        {
-            _output.WriteLine();
-            _output.WriteLine("[");
-            OutputActions(initializers, newlineBetweenItems: true);
-            _output.WriteLine();
-            _output.Write("]");
         }
     }
 
@@ -375,13 +317,6 @@ internal sealed class CSharpCodeWriter : ICodeWriter
         OutputType(typeInfo);
         _output.Write(")");
         action();
-    }
-
-    public void WriteAssign(Action left, Action right)
-    {
-        left();
-        _output.Write(" = ");
-        right();
     }
 
     public void WriteMemberAssignmentStart(string memberName)
@@ -445,48 +380,6 @@ internal sealed class CSharpCodeWriter : ICodeWriter
             OutputActions(parametersEnumerator, newlineBetweenItems: false);
         }
         _output.Write(')');
-    }
-
-    public void WriteObjectCreateAndInitialize(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions, IEnumerable<Action> initializeActions, bool singleLine = false)
-    {
-        _output.Write("new ");
-        OutputType(typeInfo);
-
-        using var parametersEnumerator = parametersActions.GetEnumerator();
-        using var initializeEnumerator = initializeActions.GetEnumerator();
-
-        var parametersExist = parametersEnumerator.MoveNext();
-        var initializeExist = initializeEnumerator.MoveNext();
-
-        if (parametersExist || !initializeExist)
-        {
-            _output.Write('(');
-            if (parametersExist)
-            {
-                OutputActions(parametersEnumerator, newlineBetweenItems: false);
-            }
-            _output.Write(')');
-        }
-
-        if (!initializeExist)
-        {
-            return;
-        }
-
-        if (singleLine)
-        {
-            _output.Write(" { ");
-            OutputActions(initializeEnumerator, newlineBetweenItems: false);
-            _output.Write(" }");
-        }
-        else
-        {
-            _output.WriteLine();
-            _output.WriteLine('{');
-            OutputActions(initializeEnumerator, newlineBetweenItems: true);
-            _output.WriteLine();
-            _output.Write("}");
-        }
     }
 
     public void WriteValueTupleCreate(IEnumerable<Action> actions)
@@ -896,11 +789,14 @@ internal sealed class CSharpCodeWriter : ICodeWriter
                 _output.Write(size);
             }
             _output.Write(']');
+
+            int nestedArrayDepth = typeInfo.NestedArrayDepth;
+            for (int i = 0; i < nestedArrayDepth - 1; i++)
+                _output.Write("[]");
         }
     }
 
-    public void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IDictionary items, Action<object> writeKey,
-        Action<object> writeValue)
+    public void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem)
     {
         _output.Write("new ");
         OutputType(typeInfo);
@@ -915,7 +811,7 @@ internal sealed class CSharpCodeWriter : ICodeWriter
 
         _output.WriteLine();
         _output.WriteLine('{');
-        OutputDictionaryItems(enumerator, writeKey, writeValue);
+        OutputItems(enumerator, writeItem, newlineBetweenItems: true);
         _output.WriteLine();
         _output.Write('}');
     }
@@ -981,29 +877,6 @@ internal sealed class CSharpCodeWriter : ICodeWriter
                 _output.Write(", ");
 
             writeItem(items.Current);
-        } while (items.MoveNext());
-        Indent--;
-    }
-
-    private void OutputDictionaryItems(IDictionaryEnumerator items, Action<object> writeKey, Action<object> writeValue)
-    {
-        var first = true;
-        Indent++;
-        do
-        {
-            if (first)
-                first = false;
-            else
-                ContinueOnNewLine(",");
-
-            _output.WriteLine('{');
-            Indent++;
-            writeKey(items.Key);
-            ContinueOnNewLine(",");
-            writeValue(items.Value);
-            Indent--;
-            _output.WriteLine();
-            _output.Write('}');
         } while (items.MoveNext());
         Indent--;
     }

--- a/src/VarDump/CodeDom/Compiler/ICodeWriter.cs
+++ b/src/VarDump/CodeDom/Compiler/ICodeWriter.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System;
 using VarDump.CodeDom.Common;
@@ -10,11 +11,15 @@ public interface ICodeWriter
     bool SupportsCollectionExpression { get; }
 
     void WriteArrayCreate(CodeTypeInfo typeInfo, IEnumerable<Action> initializers, bool singleLine, int size = 0);
+    void WriteArrayCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem, bool singleLine, int size = 0);
+    void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IDictionary items, Action<object> writeKey, Action<object> writeValue);
     void WriteCast(CodeTypeInfo typeInfo, Action action);
 
     void WriteArrayDimension(IEnumerable<Action> initializers, bool singleLine = false);
     void WriteCollectionExpression(IEnumerable<Action> initializers, bool singleLine = false);
+    void WriteCollectionExpressionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false);
     void WriteAssign(Action left, Action right);
+    void WriteMemberAssignmentStart(string memberName);
 
     void WriteImplicitKeyValuePairCreate(Action keyAction, Action valueAction);
 
@@ -34,6 +39,7 @@ public interface ICodeWriter
     void WriteNamedArgument(string argumentName, Action value);
 
     void WriteObjectCreateAndInitialize(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions, IEnumerable<Action> initializeActions, bool singleLine = false);
+    void WriteObjectCreateAndInitializeItems(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions, IEnumerable initializers, Action<object> writeInitializer, bool singleLine = false);
 
     void WriteObjectCreate(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions);
 

--- a/src/VarDump/CodeDom/Compiler/ICodeWriter.cs
+++ b/src/VarDump/CodeDom/Compiler/ICodeWriter.cs
@@ -10,15 +10,12 @@ public interface ICodeWriter
     int Indent { get; set; }
     bool SupportsCollectionExpression { get; }
 
-    void WriteArrayCreate(CodeTypeInfo typeInfo, IEnumerable<Action> initializers, bool singleLine, int size = 0);
     void WriteArrayCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem, bool singleLine, int size = 0);
-    void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IDictionary items, Action<object> writeKey, Action<object> writeValue);
+    void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem);
     void WriteCast(CodeTypeInfo typeInfo, Action action);
 
-    void WriteArrayDimension(IEnumerable<Action> initializers, bool singleLine = false);
-    void WriteCollectionExpression(IEnumerable<Action> initializers, bool singleLine = false);
+    void WriteArrayDimensionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false);
     void WriteCollectionExpressionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false);
-    void WriteAssign(Action left, Action right);
     void WriteMemberAssignmentStart(string memberName);
 
     void WriteImplicitKeyValuePairCreate(Action keyAction, Action valueAction);
@@ -38,7 +35,6 @@ public interface ICodeWriter
 
     void WriteNamedArgument(string argumentName, Action value);
 
-    void WriteObjectCreateAndInitialize(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions, IEnumerable<Action> initializeActions, bool singleLine = false);
     void WriteObjectCreateAndInitializeItems(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions, IEnumerable initializers, Action<object> writeInitializer, bool singleLine = false);
 
     void WriteObjectCreate(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions);

--- a/src/VarDump/CodeDom/VisualBasic/VisualBasicCodeWriter.cs
+++ b/src/VarDump/CodeDom/VisualBasic/VisualBasicCodeWriter.cs
@@ -192,13 +192,6 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         value();
     }
 
-    public void WriteAssign(Action left, Action right)
-    {
-        left();
-        _output.Write(" = ");
-        right();
-    }
-
     public void WriteMemberAssignmentStart(string memberName)
     {
         WritePropertyReference(memberName, null);
@@ -384,46 +377,6 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         }
     }
 
-    public void WriteArrayCreate(CodeTypeInfo typeInfo, IEnumerable<Action> initializers, bool singleLine, int size = 0)
-    {
-        if (typeInfo is not CodeEmptyTypeInfo)
-        {
-            _output.Write("New ");
-        }
-
-        using var initializersEnumerator = initializers.GetEnumerator();
-
-        if (initializersEnumerator.MoveNext())
-        {
-            if (typeInfo is not CodeEmptyTypeInfo)
-            {
-                TypeOutput(typeInfo);
-            }
-
-            if (singleLine)
-            {
-                _output.Write("{ ");
-                OutputActions(initializersEnumerator, newlineBetweenItems: false, newLineContinuation: false);
-                _output.Write(" }");
-            }
-            else
-            {
-                _output.Write("{");
-                _output.WriteLine("");
-                OutputActions(initializersEnumerator, newlineBetweenItems: true, newLineContinuation: false);
-                _output.WriteLine("");
-                _output.Write('}');
-            }
-        }
-        else
-        {
-            OutputTypeWithoutArrayPostFix(typeInfo);
-            OutputArrayPostfixInternal(typeInfo, size);
-
-            _output.Write(" {}");
-        }
-    }
-
     public void OutputActions(IEnumerable<Action> actions, bool newlineBetweenItems,
         bool newLineContinuation = true)
     {
@@ -493,8 +446,7 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         }
     }
 
-    public void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IDictionary items, Action<object> writeKey,
-        Action<object> writeValue)
+    public void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem)
     {
         _output.Write("New ");
         OutputType(typeInfo);
@@ -509,7 +461,7 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
 
         _output.Write(" From ");
         _output.WriteLine('{');
-        OutputDictionaryItems(enumerator, writeKey, writeValue);
+        OutputItems(enumerator, writeItem, newlineBetweenItems: true, newLineContinuation: false);
         _output.WriteLine();
         _output.Write('}');
     }
@@ -533,50 +485,28 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         Indent--;
     }
 
-    private void OutputDictionaryItems(IDictionaryEnumerator items, Action<object> writeKey, Action<object> writeValue)
+    public void WriteArrayDimensionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false)
     {
-        var first = true;
-        Indent++;
-        do
-        {
-            if (first)
-                first = false;
-            else
-                ContinueOnNewLine(",", newLineContinuation: false);
+        var enumerator = items.GetEnumerator();
+        using var enumeratorDisposable = enumerator as IDisposable;
+        var hasItems = enumerator.MoveNext();
 
-            _output.WriteLine('{');
-            Indent++;
-            writeKey(items.Key);
-            ContinueOnNewLine(",", newLineContinuation: false);
-            writeValue(items.Value);
-            Indent--;
-            _output.WriteLine();
-            _output.Write('}');
-        } while (items.MoveNext());
-        Indent--;
-    }
-
-    public void WriteArrayDimension(IEnumerable<Action> initializers, bool singleLine = false)
-    {
         if (singleLine)
         {
             _output.Write("{ ");
-            OutputActions(initializers, newlineBetweenItems: false, newLineContinuation: false);
+            if (hasItems)
+                OutputItems(enumerator, writeItem, newlineBetweenItems: false, newLineContinuation: false);
             _output.Write(" }");
         }
         else
         {
             _output.Write("{");
             _output.WriteLine();
-            OutputActions(initializers, newlineBetweenItems: true, newLineContinuation: false);
+            if (hasItems)
+                OutputItems(enumerator, writeItem, newlineBetweenItems: true, newLineContinuation: false);
             _output.WriteLine();
             _output.Write("}");
         }
-    }
-
-    public void WriteCollectionExpression(IEnumerable<Action> initializers, bool singleLine = false)
-    {
-        WriteArrayDimension(initializers, singleLine);
     }
 
     public void WriteCollectionExpressionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false)
@@ -692,55 +622,6 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
             OutputActions(parametersEnumerator, newlineBetweenItems: false);
         }
         _output.Write(')');
-    }
-
-    public void WriteObjectCreateAndInitialize(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions, IEnumerable<Action> initializeActions, bool singleLine = false)
-    {
-        _output.Write("New ");
-        OutputType(typeInfo);
-
-        using var parametersEnumerator = parametersActions.GetEnumerator();
-        using var initializeEnumerator = initializeActions.GetEnumerator();
-
-        var parametersExist = parametersEnumerator.MoveNext();
-        var initializeExist = initializeEnumerator.MoveNext();
-
-        if (parametersExist || !initializeExist)
-        {
-            // always write out the () to disambiguate cases like "New System.Random().Next(x,y)"
-            _output.Write('(');
-            if (parametersExist)
-            {
-                OutputActions(parametersEnumerator, newlineBetweenItems: false);
-            }
-            _output.Write(')');
-        }
-
-        if (!initializeExist)
-        {
-            return;
-        }
-
-        _output.Write(typeInfo switch
-        {
-            CodeEmptyTypeInfo => "With ",
-            CodeCollectionTypeInfo => " From ",
-            _ => " With "
-        });
-
-        if (singleLine)
-        {
-            _output.Write("{ ");
-            OutputActions(initializeEnumerator, newlineBetweenItems: false, newLineContinuation: false);
-            _output.Write(" }");
-        }
-        else
-        {
-            _output.WriteLine('{');
-            OutputActions(initializeEnumerator, newlineBetweenItems: true, newLineContinuation: false);
-            _output.WriteLine();
-            _output.Write('}');
-        }
     }
 
     public void WriteObjectCreateAndInitializeItems(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions,

--- a/src/VarDump/CodeDom/VisualBasic/VisualBasicCodeWriter.cs
+++ b/src/VarDump/CodeDom/VisualBasic/VisualBasicCodeWriter.cs
@@ -401,7 +401,7 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
             else
             {
                 if (newlineBetweenItems)
-                    ContinueOnNewLine(",", newLineContinuation);
+                    ContinueOnNewLine(',', newLineContinuation);
                 else
                     _output.Write(", ");
             }
@@ -476,7 +476,7 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
             if (first)
                 first = false;
             else if (newlineBetweenItems)
-                ContinueOnNewLine(",", newLineContinuation);
+                ContinueOnNewLine(',', newLineContinuation);
             else
                 _output.Write(", ");
 
@@ -961,9 +961,9 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         }
     }
 
-    public void ContinueOnNewLine(string st, bool newLineContinuation = true)
+    private void ContinueOnNewLine(char ch, bool newLineContinuation = true)
     {
-        _output.Write(st);
+        _output.Write(ch);
         _output.WriteLine(newLineContinuation ? " _" : "");
-    }
+    }   
 }

--- a/src/VarDump/CodeDom/VisualBasic/VisualBasicCodeWriter.cs
+++ b/src/VarDump/CodeDom/VisualBasic/VisualBasicCodeWriter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -196,6 +197,12 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         left();
         _output.Write(" = ");
         right();
+    }
+
+    public void WriteMemberAssignmentStart(string memberName)
+    {
+        WritePropertyReference(memberName, null);
+        _output.Write(" = ");
     }
 
     public void WriteDefaultValue(CodeTypeInfo typeInfo)
@@ -451,6 +458,104 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         Indent--;
     }
 
+    public void WriteArrayCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem, bool singleLine, int size = 0)
+    {
+        if (typeInfo is not CodeEmptyTypeInfo)
+            _output.Write("New ");
+
+        var enumerator = items.GetEnumerator();
+        using var enumeratorDisposable = enumerator as IDisposable;
+        if (enumerator.MoveNext())
+        {
+            if (typeInfo is not CodeEmptyTypeInfo)
+                TypeOutput(typeInfo);
+
+            if (singleLine)
+            {
+                _output.Write("{ ");
+                OutputItems(enumerator, writeItem, newlineBetweenItems: false, newLineContinuation: false);
+                _output.Write(" }");
+            }
+            else
+            {
+                _output.Write("{");
+                _output.WriteLine("");
+                OutputItems(enumerator, writeItem, newlineBetweenItems: true, newLineContinuation: false);
+                _output.WriteLine("");
+                _output.Write('}');
+            }
+        }
+        else
+        {
+            OutputTypeWithoutArrayPostFix(typeInfo);
+            OutputArrayPostfixInternal(typeInfo, size);
+            _output.Write(" {}");
+        }
+    }
+
+    public void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IDictionary items, Action<object> writeKey,
+        Action<object> writeValue)
+    {
+        _output.Write("New ");
+        OutputType(typeInfo);
+
+        var enumerator = items.GetEnumerator();
+        using var enumeratorDisposable = enumerator as IDisposable;
+        if (!enumerator.MoveNext())
+        {
+            _output.Write("()");
+            return;
+        }
+
+        _output.Write(" From ");
+        _output.WriteLine('{');
+        OutputDictionaryItems(enumerator, writeKey, writeValue);
+        _output.WriteLine();
+        _output.Write('}');
+    }
+
+    private void OutputItems(IEnumerator items, Action<object> writeItem, bool newlineBetweenItems,
+        bool newLineContinuation = true)
+    {
+        var first = true;
+        Indent++;
+        do
+        {
+            if (first)
+                first = false;
+            else if (newlineBetweenItems)
+                ContinueOnNewLine(",", newLineContinuation);
+            else
+                _output.Write(", ");
+
+            writeItem(items.Current);
+        } while (items.MoveNext());
+        Indent--;
+    }
+
+    private void OutputDictionaryItems(IDictionaryEnumerator items, Action<object> writeKey, Action<object> writeValue)
+    {
+        var first = true;
+        Indent++;
+        do
+        {
+            if (first)
+                first = false;
+            else
+                ContinueOnNewLine(",", newLineContinuation: false);
+
+            _output.WriteLine('{');
+            Indent++;
+            writeKey(items.Key);
+            ContinueOnNewLine(",", newLineContinuation: false);
+            writeValue(items.Value);
+            Indent--;
+            _output.WriteLine();
+            _output.Write('}');
+        } while (items.MoveNext());
+        Indent--;
+    }
+
     public void WriteArrayDimension(IEnumerable<Action> initializers, bool singleLine = false)
     {
         if (singleLine)
@@ -472,6 +577,11 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
     public void WriteCollectionExpression(IEnumerable<Action> initializers, bool singleLine = false)
     {
         WriteArrayDimension(initializers, singleLine);
+    }
+
+    public void WriteCollectionExpressionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false)
+    {
+        WriteArrayCreateItems(new CodeEmptyTypeInfo(), items, writeItem, singleLine);
     }
 
     public void WriteCast(CodeTypeInfo typeInfo, Action action)
@@ -628,6 +738,49 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         {
             _output.WriteLine('{');
             OutputActions(initializeEnumerator, newlineBetweenItems: true, newLineContinuation: false);
+            _output.WriteLine();
+            _output.Write('}');
+        }
+    }
+
+    public void WriteObjectCreateAndInitializeItems(CodeTypeInfo typeInfo, IEnumerable<Action> parametersActions,
+        IEnumerable initializers, Action<object> writeInitializer, bool singleLine = false)
+    {
+        _output.Write("New ");
+        OutputType(typeInfo);
+        using var parametersEnumerator = parametersActions.GetEnumerator();
+        var initializerEnumerator = initializers.GetEnumerator();
+        using var initializerEnumeratorDisposable = initializerEnumerator as IDisposable;
+        var parametersExist = parametersEnumerator.MoveNext();
+        var initializerExists = initializerEnumerator.MoveNext();
+
+        if (parametersExist || !initializerExists)
+        {
+            _output.Write('(');
+            if (parametersExist)
+                OutputActions(parametersEnumerator, newlineBetweenItems: false);
+            _output.Write(')');
+        }
+        if (!initializerExists)
+            return;
+
+        _output.Write(typeInfo switch
+        {
+            CodeEmptyTypeInfo => "With ",
+            CodeCollectionTypeInfo => " From ",
+            _ => " With "
+        });
+
+        if (singleLine)
+        {
+            _output.Write("{ ");
+            OutputItems(initializerEnumerator, writeInitializer, newlineBetweenItems: false, newLineContinuation: false);
+            _output.Write(" }");
+        }
+        else
+        {
+            _output.WriteLine('{');
+            OutputItems(initializerEnumerator, writeInitializer, newlineBetweenItems: true, newLineContinuation: false);
             _output.WriteLine();
             _output.Write('}');
         }

--- a/src/VarDump/VarDump.csproj
+++ b/src/VarDump/VarDump.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>VarDump</AssemblyName>
-    <AssemblyVersion>2.0.5.0</AssemblyVersion>
-    <FileVersion>2.0.5.0</FileVersion>
+    <AssemblyVersion>2.0.6.0</AssemblyVersion>
+    <FileVersion>2.0.6.0</FileVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2023 - $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>VarDump</Title>
-    <Version>2.0.5.0</Version>
+    <Version>2.0.6.0</Version>
     <Description>VarDump is a utility for serialization runtime objects to C# and Visual Basic string.</Description>
     <PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -37,6 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.303" />
   </ItemGroup>
 </Project>

--- a/src/VarDump/VarDump.csproj
+++ b/src/VarDump/VarDump.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>VarDump</AssemblyName>
-    <AssemblyVersion>2.0.4.0</AssemblyVersion>
-    <FileVersion>2.0.4.0</FileVersion>
+    <AssemblyVersion>2.0.5.0</AssemblyVersion>
+    <FileVersion>2.0.5.0</FileVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2023 - $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>VarDump</Title>
-    <Version>2.0.4.0</Version>
+    <Version>2.0.5.0</Version>
     <Description>VarDump is a utility for serialization runtime objects to C# and Visual Basic string.</Description>
     <PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -34,5 +34,9 @@
       <PackagePath>\</PackagePath>
     </None>
     <InternalsVisibleTo Include="$(AssemblyName).UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.301" />
   </ItemGroup>
 </Project>

--- a/src/VarDump/Visitor/KnownObjects/AnonymousVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/AnonymousVisitor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Linq;
-using System.Reflection;
+using System;
 using VarDump.CodeDom.Common;
 using VarDump.CodeDom.Compiler;
 using VarDump.Utils;
@@ -12,11 +9,9 @@ namespace VarDump.Visitor.KnownObjects;
 
 internal sealed class AnonymousVisitor : IKnownObjectVisitor
 {
-    private static readonly ConcurrentDictionary<PropertiesCacheKey, AnonymousProperty[]> PropertiesCache = new();
     private readonly INextDepthVisitor _nextDepthVisitor;
     private readonly IObjectDescriptor _anonymousObjectDescriptor;
     private readonly ICodeWriter _codeWriter;
-    private readonly BindingFlags _getPropertiesBindingFlags;
 
     public AnonymousVisitor(INextDepthVisitor nextDepthVisitor,
         ICodeWriter codeWriter,
@@ -24,13 +19,10 @@ internal sealed class AnonymousVisitor : IKnownObjectVisitor
     {
         _nextDepthVisitor = nextDepthVisitor;
         _codeWriter = codeWriter;
-        _getPropertiesBindingFlags = options.GetPropertiesBindingFlags;
+        _anonymousObjectDescriptor = new ObjectPropertiesDescriptor(options.GetPropertiesBindingFlags, false);
 
-        if (options.Descriptors == null || options.Descriptors.Count == 0)
-            return;
-
-        _anonymousObjectDescriptor = new ObjectPropertiesDescriptor(options.GetPropertiesBindingFlags, false)
-            .ApplyMiddleware(options.Descriptors);
+        if (options.Descriptors?.Count > 0)
+            _anonymousObjectDescriptor = _anonymousObjectDescriptor.ApplyMiddleware(options.Descriptors);
     }
 
     public string Id => "Anonymous";
@@ -46,12 +38,6 @@ internal sealed class AnonymousVisitor : IKnownObjectVisitor
 
     public void Visit(object obj, Type objectType, VisitContext context)
     {
-        if (_anonymousObjectDescriptor == null)
-        {
-            VisitCachedProperties(obj, objectType, context);
-            return;
-        }
-
         var properties = _anonymousObjectDescriptor.GetObjectDescription(obj, objectType).Properties;
 
         _codeWriter.WriteObjectCreateAndInitializeItems(new CodeAnonymousTypeInfo(), [], properties, property =>
@@ -67,68 +53,5 @@ internal sealed class AnonymousVisitor : IKnownObjectVisitor
                 _nextDepthVisitor.Visit(description.Value, context);
             }
         });
-    }
-
-    private void VisitCachedProperties(object obj, Type objectType, VisitContext context)
-    {
-        var properties = PropertiesCache.GetOrAdd(
-            new PropertiesCacheKey(objectType, _getPropertiesBindingFlags),
-            static key => key.Type
-                .GetProperties(key.BindingFlags)
-                .Where(property => property.CanRead && !ReflectionUtils.IsIndexer(property))
-                .Select(property => new AnonymousProperty(property))
-                .ToArray());
-
-        _codeWriter.WriteObjectCreateAndInitializeItems(new CodeAnonymousTypeInfo(), [], properties, property =>
-        {
-            var description = (AnonymousProperty)property;
-            var value = ReflectionUtils.GetValue(description.Property, obj);
-            _codeWriter.WriteMemberAssignmentStart(description.Name);
-            if (description.Type.IsNullableType() || value == null)
-            {
-                _codeWriter.WriteCast(description.Type, () => _nextDepthVisitor.Visit(value, context));
-            }
-            else
-            {
-                _nextDepthVisitor.Visit(value, context);
-            }
-        });
-    }
-
-    private sealed class AnonymousProperty(PropertyInfo property)
-    {
-        public PropertyInfo Property { get; } = property;
-        public string Name { get; } = property.Name;
-        public Type Type { get; } = property.PropertyType;
-    }
-
-    private struct PropertiesCacheKey : IEquatable<PropertiesCacheKey>
-    {
-        public PropertiesCacheKey(Type type, BindingFlags bindingFlags)
-        {
-            Type = type;
-            BindingFlags = bindingFlags;
-        }
-
-        public Type Type { get; }
-        public BindingFlags BindingFlags { get; }
-
-        public bool Equals(PropertiesCacheKey other)
-        {
-            return Type == other.Type && BindingFlags == other.BindingFlags;
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is PropertiesCacheKey other && Equals(other);
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((Type?.GetHashCode() ?? 0) * 397) ^ (int)BindingFlags;
-            }
-        }
     }
 }

--- a/src/VarDump/Visitor/KnownObjects/AnonymousVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/AnonymousVisitor.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Linq;
+using System.Reflection;
 using VarDump.CodeDom.Common;
 using VarDump.CodeDom.Compiler;
 using VarDump.Utils;
@@ -10,9 +12,11 @@ namespace VarDump.Visitor.KnownObjects;
 
 internal sealed class AnonymousVisitor : IKnownObjectVisitor
 {
+    private static readonly ConcurrentDictionary<PropertiesCacheKey, AnonymousProperty[]> PropertiesCache = new();
     private readonly INextDepthVisitor _nextDepthVisitor;
     private readonly IObjectDescriptor _anonymousObjectDescriptor;
     private readonly ICodeWriter _codeWriter;
+    private readonly BindingFlags _getPropertiesBindingFlags;
 
     public AnonymousVisitor(INextDepthVisitor nextDepthVisitor,
         ICodeWriter codeWriter,
@@ -20,12 +24,13 @@ internal sealed class AnonymousVisitor : IKnownObjectVisitor
     {
         _nextDepthVisitor = nextDepthVisitor;
         _codeWriter = codeWriter;
+        _getPropertiesBindingFlags = options.GetPropertiesBindingFlags;
 
-        _anonymousObjectDescriptor = new ObjectPropertiesDescriptor(options.GetPropertiesBindingFlags, false);
-        if (options.Descriptors?.Count > 0)
-        {
-            _anonymousObjectDescriptor = _anonymousObjectDescriptor.ApplyMiddleware(options.Descriptors);
-        }
+        if (options.Descriptors == null || options.Descriptors.Count == 0)
+            return;
+
+        _anonymousObjectDescriptor = new ObjectPropertiesDescriptor(options.GetPropertiesBindingFlags, false)
+            .ApplyMiddleware(options.Descriptors);
     }
 
     public string Id => "Anonymous";
@@ -41,22 +46,89 @@ internal sealed class AnonymousVisitor : IKnownObjectVisitor
 
     public void Visit(object obj, Type objectType, VisitContext context)
     {
-        var initializeActions = _anonymousObjectDescriptor.GetObjectDescription(obj, objectType)
-            .Properties
-            .Select(pv => (Action)(() => _codeWriter.WriteAssign(
-                () => _codeWriter.WritePropertyReference(pv.Name, null),
-                () =>
-                {
-                    if (pv.Type.IsNullableType() || pv.Value == null)
-                    {
-                        _codeWriter.WriteCast(pv.Type, () => _nextDepthVisitor.Visit(pv.Value, context));
-                    }
-                    else
-                    {
-                        _nextDepthVisitor.Visit(pv.Value, context);
-                    }
-                })));
+        if (_anonymousObjectDescriptor == null)
+        {
+            VisitCachedProperties(obj, objectType, context);
+            return;
+        }
 
-        _codeWriter.WriteObjectCreateAndInitialize(new CodeAnonymousTypeInfo(), [], initializeActions);
+        var properties = _anonymousObjectDescriptor.GetObjectDescription(obj, objectType).Properties;
+
+        _codeWriter.WriteObjectCreateAndInitializeItems(new CodeAnonymousTypeInfo(), [], properties, property =>
+        {
+            var description = (PropertyDescription)property;
+            _codeWriter.WriteMemberAssignmentStart(description.Name);
+            if (description.Type.IsNullableType() || description.Value == null)
+            {
+                _codeWriter.WriteCast(description.Type, () => _nextDepthVisitor.Visit(description.Value, context));
+            }
+            else
+            {
+                _nextDepthVisitor.Visit(description.Value, context);
+            }
+        });
+    }
+
+    private void VisitCachedProperties(object obj, Type objectType, VisitContext context)
+    {
+        var properties = PropertiesCache.GetOrAdd(
+            new PropertiesCacheKey(objectType, _getPropertiesBindingFlags),
+            static key => key.Type
+                .GetProperties(key.BindingFlags)
+                .Where(property => property.CanRead && !ReflectionUtils.IsIndexer(property))
+                .Select(property => new AnonymousProperty(property))
+                .ToArray());
+
+        _codeWriter.WriteObjectCreateAndInitializeItems(new CodeAnonymousTypeInfo(), [], properties, property =>
+        {
+            var description = (AnonymousProperty)property;
+            var value = ReflectionUtils.GetValue(description.Property, obj);
+            _codeWriter.WriteMemberAssignmentStart(description.Name);
+            if (description.Type.IsNullableType() || value == null)
+            {
+                _codeWriter.WriteCast(description.Type, () => _nextDepthVisitor.Visit(value, context));
+            }
+            else
+            {
+                _nextDepthVisitor.Visit(value, context);
+            }
+        });
+    }
+
+    private sealed class AnonymousProperty(PropertyInfo property)
+    {
+        public PropertyInfo Property { get; } = property;
+        public string Name { get; } = property.Name;
+        public Type Type { get; } = property.PropertyType;
+    }
+
+    private struct PropertiesCacheKey : IEquatable<PropertiesCacheKey>
+    {
+        public PropertiesCacheKey(Type type, BindingFlags bindingFlags)
+        {
+            Type = type;
+            BindingFlags = bindingFlags;
+        }
+
+        public Type Type { get; }
+        public BindingFlags BindingFlags { get; }
+
+        public bool Equals(PropertiesCacheKey other)
+        {
+            return Type == other.Type && BindingFlags == other.BindingFlags;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PropertiesCacheKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Type?.GetHashCode() ?? 0) * 397) ^ (int)BindingFlags;
+            }
+        }
     }
 }

--- a/src/VarDump/Visitor/KnownObjects/CollectionItemMarker.cs
+++ b/src/VarDump/Visitor/KnownObjects/CollectionItemMarker.cs
@@ -1,0 +1,6 @@
+namespace VarDump.Visitor.KnownObjects;
+
+internal static class CollectionItemMarker
+{
+    public static readonly object TooManyItems = new();
+}

--- a/src/VarDump/Visitor/KnownObjects/CollectionVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/CollectionVisitor.cs
@@ -132,6 +132,12 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
     private void VisitSimpleCollection(IEnumerable enumerable, Type elementType, VisitContext context)
     {
+        if (_options.MaxCollectionSize == int.MaxValue && (enumerable is not Array array || array.Rank == 1))
+        {
+            VisitSimpleCollectionStreaming(enumerable, elementType, context);
+            return;
+        }
+
         var items = enumerable.Cast<object>().Select(item => (Action)(() => _nextDepthVisitor.Visit(item, context)));
 
         if (_options.MaxCollectionSize < int.MaxValue)
@@ -223,6 +229,66 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         }
     }
 
+    private void VisitSimpleCollectionStreaming(IEnumerable enumerable, Type elementType, VisitContext context)
+    {
+        var type = enumerable.GetType();
+        var isImmutableOrFrozen = type.IsPublicImmutableOrFrozenCollection();
+        var isCollection = IsCollection(enumerable);
+        var singleLine = typeof(string) != elementType
+                         && ReflectionUtils.IsPrimitive(elementType)
+                         && _options.PrimitiveCollectionLayout == CollectionLayout.SingleLine;
+        Action<object> writeItem = item => _nextDepthVisitor.Visit(item, context);
+
+        if (type.IsArray || isImmutableOrFrozen || !type.IsPublic || !isCollection)
+        {
+            var isQueryable = IsQueryable(type);
+            var arrayType = isImmutableOrFrozen || !type.IsPublic || isQueryable ? elementType.MakeArrayType() : type;
+
+            void WriteArrayCreate() => _codeWriter.WriteArrayCreateItems(arrayType, enumerable, writeItem, singleLine);
+
+            if (isImmutableOrFrozen)
+            {
+                _codeWriter.WriteMethodInvoke(() =>
+                    _codeWriter.WriteMethodReference(WriteArrayCreate, $"To{type.GetImmutableOrFrozenTypeName()}"), []);
+            }
+            else if (isQueryable)
+            {
+                _codeWriter.WriteMethodInvoke(() =>
+                    _codeWriter.WriteMethodReference(WriteArrayCreate, "AsQueryable"), []);
+            }
+            else if (type.IsArray
+                     && _options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
+                     && _codeWriter.SupportsCollectionExpression)
+            {
+                _codeWriter.WriteCollectionExpressionItems(enumerable, writeItem, singleLine);
+            }
+            else
+            {
+                WriteArrayCreate();
+            }
+
+            return;
+        }
+
+        if (type.IsReadonlyCollection())
+        {
+            var typeInfo = new CodeCollectionTypeInfo(typeof(List<>).MakeGenericType(elementType));
+            void WriteCollectionCreate() => _codeWriter.WriteObjectCreateAndInitializeItems(typeInfo, [], enumerable, writeItem, singleLine);
+            _codeWriter.WriteMethodInvoke(() => _codeWriter.WriteMethodReference(WriteCollectionCreate, "AsReadOnly"), []);
+            return;
+        }
+
+        var collectionTypeInfo = new CodeCollectionTypeInfo(type);
+        if (_options.CollectionLiteralStyle == CollectionLiteralStyle.Expression && _codeWriter.SupportsCollectionExpression)
+        {
+            _codeWriter.WriteCollectionExpressionItems(enumerable, writeItem, singleLine);
+        }
+        else
+        {
+            _codeWriter.WriteObjectCreateAndInitializeItems(collectionTypeInfo, [], enumerable, writeItem, singleLine);
+        }
+    }
+
     private static bool IsQueryable(Type type)
     {
         var isGenericType = type.IsGenericType;
@@ -264,6 +330,16 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
     private void VisitAnonymousCollection(IEnumerable enumerable, VisitContext context)
     {
+        if (_options.MaxCollectionSize == int.MaxValue && enumerable is Array { Rank: 1 })
+        {
+            _codeWriter.WriteArrayCreateItems(
+                new CodeAnonymousTypeInfo { ArrayRank = 1 },
+                enumerable,
+                item => _nextDepthVisitor.Visit(item, context),
+                singleLine: false);
+            return;
+        }
+
         var items = enumerable.Cast<object>().Select(item => (Action)(() => _nextDepthVisitor.Visit(item, context)));
 
         if (_options.MaxCollectionSize < int.MaxValue)

--- a/src/VarDump/Visitor/KnownObjects/CollectionVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/CollectionVisitor.cs
@@ -80,12 +80,7 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
     {
         var type = collection.GetType();
 
-        var items = VisitGroupings(collection.Cast<object>(), context);
-
-        if (_options.MaxCollectionSize < int.MaxValue)
-        {
-            items = items.Take(_options.MaxCollectionSize + 1).Replace(_options.MaxCollectionSize, () => _codeWriter.WriteTooManyItems(_options.MaxCollectionSize));
-        }
+        var items = GetItems(VisitGroupings(collection.Cast<object>()));
 
         var isLookup = type.IsLookup();
 
@@ -122,7 +117,8 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
                 WriteValueLambdaExpression
             ]);
 
-        void WriteArrayCreate() => _codeWriter.WriteArrayCreate(new CodeAnonymousTypeInfo { ArrayRank = 1 }, items, false);
+        void WriteArrayCreate() => _codeWriter.WriteArrayCreateItems(
+            new CodeAnonymousTypeInfo { ArrayRank = 1 }, items, item => WriteCollectionItem(item, context), false);
         void WriteVariableReference() => _codeWriter.WriteVariableReference("grp");
         void WriteKeyLambdaPropertyExpression() => _codeWriter.WritePropertyReference("Key", WriteVariableReference);
         void WriteKeyLambdaExpression() => _codeWriter.WriteLambdaExpression(WriteKeyLambdaPropertyExpression, [WriteVariableReference]);
@@ -132,18 +128,7 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
     private void VisitSimpleCollection(IEnumerable enumerable, Type elementType, VisitContext context)
     {
-        if (_options.MaxCollectionSize == int.MaxValue && (enumerable is not Array array || array.Rank == 1))
-        {
-            VisitSimpleCollectionStreaming(enumerable, elementType, context);
-            return;
-        }
-
-        var items = enumerable.Cast<object>().Select(item => (Action)(() => _nextDepthVisitor.Visit(item, context)));
-
-        if (_options.MaxCollectionSize < int.MaxValue)
-        {
-            items = items.Take(_options.MaxCollectionSize + 1).Replace(_options.MaxCollectionSize, () => _codeWriter.WriteTooManyItems(_options.MaxCollectionSize));
-        }
+        IEnumerable items = GetItems(enumerable);
 
         var type = enumerable.GetType();
 
@@ -158,7 +143,7 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         {
             if (type.IsArray && ((Array)enumerable).Rank > 1 && ((Array)enumerable).Length > 0)
             {
-                items = ChunkMultiDimensionalArrayExpression((Array)enumerable, items, singleLine);
+                items = ChunkMultiDimensionalArrayItems((Array)enumerable, items, singleLine);
                 singleLine = false;
             }
 
@@ -166,7 +151,8 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
             var arrayType = isImmutableOrFrozen || !type.IsPublic || isQueryable ? elementType.MakeArrayType() : type;
 
-            void WriteArrayCreate() => _codeWriter.WriteArrayCreate(arrayType, items, singleLine: singleLine);
+            void WriteArrayCreate() => _codeWriter.WriteArrayCreateItems(
+                arrayType, items, item => WriteArrayItem(item, context), singleLine);
 
             void WriteArrayOrCollectionExpression()
             {
@@ -175,7 +161,7 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
                     && _options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
                     && _codeWriter.SupportsCollectionExpression)
                 {
-                    _codeWriter.WriteCollectionExpression(items, singleLine);
+                    _codeWriter.WriteCollectionExpressionItems(items, item => WriteArrayItem(item, context), singleLine);
                     return;
                 }
 
@@ -217,75 +203,17 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
         return;
 
-        Action ResolveCollectionCreateAction(CodeTypeInfo collectionTypeInfo, IEnumerable<Action> initializers, bool useSingleLine)
+        Action ResolveCollectionCreateAction(CodeTypeInfo collectionType, IEnumerable initializers, bool useSingleLine)
         {
             if (_options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
                 && _codeWriter.SupportsCollectionExpression)
             {
-                return () => _codeWriter.WriteCollectionExpression(initializers, useSingleLine);
+                return () => _codeWriter.WriteCollectionExpressionItems(initializers,
+                    item => WriteCollectionItem(item, context), useSingleLine);
             }
 
-            return () => _codeWriter.WriteObjectCreateAndInitialize(collectionTypeInfo, [], initializers, useSingleLine);
-        }
-    }
-
-    private void VisitSimpleCollectionStreaming(IEnumerable enumerable, Type elementType, VisitContext context)
-    {
-        var type = enumerable.GetType();
-        var isImmutableOrFrozen = type.IsPublicImmutableOrFrozenCollection();
-        var isCollection = IsCollection(enumerable);
-        var singleLine = typeof(string) != elementType
-                         && ReflectionUtils.IsPrimitive(elementType)
-                         && _options.PrimitiveCollectionLayout == CollectionLayout.SingleLine;
-        Action<object> writeItem = item => _nextDepthVisitor.Visit(item, context);
-
-        if (type.IsArray || isImmutableOrFrozen || !type.IsPublic || !isCollection)
-        {
-            var isQueryable = IsQueryable(type);
-            var arrayType = isImmutableOrFrozen || !type.IsPublic || isQueryable ? elementType.MakeArrayType() : type;
-
-            void WriteArrayCreate() => _codeWriter.WriteArrayCreateItems(arrayType, enumerable, writeItem, singleLine);
-
-            if (isImmutableOrFrozen)
-            {
-                _codeWriter.WriteMethodInvoke(() =>
-                    _codeWriter.WriteMethodReference(WriteArrayCreate, $"To{type.GetImmutableOrFrozenTypeName()}"), []);
-            }
-            else if (isQueryable)
-            {
-                _codeWriter.WriteMethodInvoke(() =>
-                    _codeWriter.WriteMethodReference(WriteArrayCreate, "AsQueryable"), []);
-            }
-            else if (type.IsArray
-                     && _options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
-                     && _codeWriter.SupportsCollectionExpression)
-            {
-                _codeWriter.WriteCollectionExpressionItems(enumerable, writeItem, singleLine);
-            }
-            else
-            {
-                WriteArrayCreate();
-            }
-
-            return;
-        }
-
-        if (type.IsReadonlyCollection())
-        {
-            var typeInfo = new CodeCollectionTypeInfo(typeof(List<>).MakeGenericType(elementType));
-            void WriteCollectionCreate() => _codeWriter.WriteObjectCreateAndInitializeItems(typeInfo, [], enumerable, writeItem, singleLine);
-            _codeWriter.WriteMethodInvoke(() => _codeWriter.WriteMethodReference(WriteCollectionCreate, "AsReadOnly"), []);
-            return;
-        }
-
-        var collectionTypeInfo = new CodeCollectionTypeInfo(type);
-        if (_options.CollectionLiteralStyle == CollectionLiteralStyle.Expression && _codeWriter.SupportsCollectionExpression)
-        {
-            _codeWriter.WriteCollectionExpressionItems(enumerable, writeItem, singleLine);
-        }
-        else
-        {
-            _codeWriter.WriteObjectCreateAndInitializeItems(collectionTypeInfo, [], enumerable, writeItem, singleLine);
+            return () => _codeWriter.WriteObjectCreateAndInitializeItems(collectionType, [], initializers,
+                item => WriteCollectionItem(item, context), useSingleLine);
         }
     }
 
@@ -306,7 +234,7 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         return type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IQueryable<>));
     }
 
-    private IEnumerable<Action> ChunkMultiDimensionalArrayExpression(Array array, IEnumerable<Action> enumerable,
+    private static IEnumerable<object> ChunkMultiDimensionalArrayItems(Array array, IEnumerable enumerable,
         bool singleLine)
     {
         var dimensions = new int[array.Rank - 1];
@@ -316,13 +244,14 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
             dimensions[i] = array.GetLength(i + 1);
         }
 
-        IEnumerable<Action> result = enumerable;
+        IEnumerable<object> result = enumerable.Cast<object>();
 
         for (var index = dimensions.Length - 1; index >= 0; index--)
         {
             var dimension = dimensions[index];
             var index1 = index;
-            result = result.Chunk(dimension).Select(x => (Action)(() => _codeWriter.WriteArrayDimension(x, singleLine && index1 == dimensions.Length - 1)));
+            result = result.Chunk(dimension).Select(object (x) => new ArrayDimension(x,
+                singleLine && index1 == dimensions.Length - 1));
         }
 
         return result;
@@ -330,22 +259,7 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
     private void VisitAnonymousCollection(IEnumerable enumerable, VisitContext context)
     {
-        if (_options.MaxCollectionSize == int.MaxValue && enumerable is Array { Rank: 1 })
-        {
-            _codeWriter.WriteArrayCreateItems(
-                new CodeAnonymousTypeInfo { ArrayRank = 1 },
-                enumerable,
-                item => _nextDepthVisitor.Visit(item, context),
-                singleLine: false);
-            return;
-        }
-
-        var items = enumerable.Cast<object>().Select(item => (Action)(() => _nextDepthVisitor.Visit(item, context)));
-
-        if (_options.MaxCollectionSize < int.MaxValue)
-        {
-            items = items.Take(_options.MaxCollectionSize + 1).Replace(_options.MaxCollectionSize, () => _codeWriter.WriteTooManyItems(_options.MaxCollectionSize));
-        }
+        IEnumerable items = GetItems(enumerable);
 
         var type = enumerable.GetType();
 
@@ -356,12 +270,13 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         if (type.IsArray && ((Array)enumerable).Rank > 1 && ((Array)enumerable).Length > 0)
         {
             typeInfo.ArrayRank = ((Array)enumerable).Rank;
-            items = ChunkMultiDimensionalArrayExpression((Array)enumerable, items, false);
+            items = ChunkMultiDimensionalArrayItems((Array)enumerable, items, false);
         }
 
-        Action createAction = () => _codeWriter.WriteArrayCreate(typeInfo, items, false);
+        Action createAction = () => _codeWriter.WriteArrayCreateItems(typeInfo, items,
+            item => WriteArrayItem(item, context), false);
 
-        if (isImmutableOrFrozen || enumerable is IList && !type.IsArray)
+        if (isImmutableOrFrozen || (enumerable is IList && !type.IsArray))
         {
             _codeWriter.WriteMethodInvoke(() =>
                 _codeWriter.WriteMethodReference(createAction, $"To{type.GetImmutableOrFrozenTypeName()}"), []);
@@ -388,11 +303,60 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         return new KeyValuePair<object, IEnumerable>(fieldValues[0], (IEnumerable)fieldValues[1]);
     }
 
-    private IEnumerable<Action> VisitGroupings(IEnumerable<object> objects, VisitContext context)
+    private void WriteArrayItem(object item, VisitContext context)
+    {
+        if (item is ArrayDimension dimension)
+        {
+            _codeWriter.WriteArrayDimensionItems(dimension.Items,
+                nestedItem => WriteArrayItem(nestedItem, context), dimension.SingleLine);
+            return;
+        }
+
+        WriteCollectionItem(item, context);
+    }
+
+    private void WriteCollectionItem(object item, VisitContext context)
+    {
+        if (ReferenceEquals(item, CollectionItemMarker.TooManyItems))
+        {
+            _codeWriter.WriteTooManyItems(_options.MaxCollectionSize);
+            return;
+        }
+
+        _nextDepthVisitor.Visit(item, context);
+    }
+
+    private IEnumerable GetItems(IEnumerable items)
+    {
+        return _options.MaxCollectionSize == int.MaxValue ? items : TakeItems(items);
+    }
+
+    private IEnumerable<object> TakeItems(IEnumerable items)
+    {
+        var count = 0;
+        foreach (var item in items)
+        {
+            if (count++ == _options.MaxCollectionSize)
+            {
+                yield return CollectionItemMarker.TooManyItems;
+                yield break;
+            }
+
+            yield return item;
+        }
+    }
+
+    private static IEnumerable<object> VisitGroupings(IEnumerable<object> objects)
     {
         var items = objects.Select(GetIGroupingValue)
             .SelectMany(g => g.Value.Cast<object>().Select(e => new { g.Key, Element = e }));
 
-        return items.Select(item => (Action)(() => _nextDepthVisitor.Visit(item, context)));
+        return items;
+    }
+
+    private sealed class ArrayDimension(IEnumerable items, bool singleLine)
+    {
+        public IEnumerable Items { get; } = items;
+        public bool SingleLine { get; } = singleLine;
     }
 }

--- a/src/VarDump/Visitor/KnownObjects/DictionaryVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/DictionaryVisitor.cs
@@ -71,18 +71,7 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
 
     private void VisitSimpleDictionary(IDictionary dict, VisitContext context)
     {
-        if (_options.MaxCollectionSize == int.MaxValue)
-        {
-            VisitSimpleDictionaryStreaming(dict, context);
-            return;
-        }
-
-        var items = dict.Cast<object>().Select(item => (Action)(() => VisitKeyValuePairWriteImplicitly(item, context)));
-
-        if (_options.MaxCollectionSize < int.MaxValue)
-        {
-            items = items.Take(_options.MaxCollectionSize + 1).Replace(_options.MaxCollectionSize, () => _codeWriter.WriteTooManyItems(_options.MaxCollectionSize));
-        }
+        var items = GetItems(dict);
 
         var type = dict.GetType();
         var isImmutableOrFrozen = type.IsPublicImmutableOrFrozenCollection();
@@ -94,60 +83,29 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
 
             var dictionaryType = typeof(Dictionary<,>).MakeGenericType(keyType, valueType);
 
-            var dictionaryCreateAction = ResolveDictionaryCreateAction(new CodeCollectionTypeInfo(dictionaryType), items);
+            var dictionaryCreateAction = WriteDictionaryCreate(new CodeCollectionTypeInfo(dictionaryType));
 
             _codeWriter.WriteMethodInvoke(() => _codeWriter.WriteMethodReference(dictionaryCreateAction, $"To{type.GetImmutableOrFrozenTypeName()}"), []);
 
             return;
         }
 
-        ResolveDictionaryCreateAction(new CodeCollectionTypeInfo(type), items)();
+        WriteDictionaryCreate(new CodeCollectionTypeInfo(type))();
 
         return;
 
-        Action ResolveDictionaryCreateAction(CodeTypeInfo dictionaryTypeInfo, IEnumerable<Action> initializers)
+        Action WriteDictionaryCreate(CodeTypeInfo dictionaryTypeInfo)
         {
-            return () => _codeWriter.WriteObjectCreateAndInitialize(dictionaryTypeInfo, [], initializers);
+            return () => _codeWriter.WriteDictionaryCreateItems(dictionaryTypeInfo, items,
+                item => WriteDictionaryItem(item, context));
         }
-    }
-
-    private void VisitSimpleDictionaryStreaming(IDictionary dict, VisitContext context)
-    {
-        var type = dict.GetType();
-        var isImmutableOrFrozen = type.IsPublicImmutableOrFrozenCollection();
-        var dictionaryType = isImmutableOrFrozen
-            ? typeof(Dictionary<,>).MakeGenericType(
-                ReflectionUtils.GetInnerElementType(dict.Keys.GetType()),
-                ReflectionUtils.GetInnerElementType(dict.Values.GetType()))
-            : type;
-
-        void WriteDictionaryCreate() => _codeWriter.WriteDictionaryCreateItems(
-            new CodeCollectionTypeInfo(dictionaryType),
-            dict,
-            key => _nextDepthVisitor.Visit(key, context),
-            value => _nextDepthVisitor.Visit(value, context));
-
-        if (isImmutableOrFrozen)
-        {
-            _codeWriter.WriteMethodInvoke(
-                () => _codeWriter.WriteMethodReference(WriteDictionaryCreate, $"To{type.GetImmutableOrFrozenTypeName()}"),
-                []);
-            return;
-        }
-
-        WriteDictionaryCreate();
     }
 
     private void VisitAnonymousDictionary(IEnumerable dictionary, VisitContext context)
     {
         const string keyName = "Key";
         const string valueName = "Value";
-        var items = dictionary.Cast<object>().Select(o => (Action)(() => VisitKeyValuePairWriteAnonymousType(o, keyName, valueName, context)));
-
-        if (_options.MaxCollectionSize < int.MaxValue)
-        {
-            items = items.Take(_options.MaxCollectionSize + 1).Replace(_options.MaxCollectionSize, () => _codeWriter.WriteTooManyItems(_options.MaxCollectionSize));
-        }
+        var items = GetItems(dictionary);
         
         var type = dictionary.GetType();
 
@@ -159,7 +117,8 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
 
         _codeWriter.WriteMethodInvoke(() =>
                 _codeWriter.WriteMethodReference(
-                    () => _codeWriter.WriteArrayCreate(new CodeAnonymousTypeInfo { ArrayRank = 1 }, items, false),
+                    () => _codeWriter.WriteArrayCreateItems(new CodeAnonymousTypeInfo { ArrayRank = 1 }, items,
+                        item => WriteAnonymousDictionaryItem(item, keyName, valueName, context), false),
                     methodName),
             [
                 WriteKeyLambda,
@@ -181,15 +140,66 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
         _codeWriter.WriteImplicitKeyValuePairCreate(() => _nextDepthVisitor.Visit(propertyValues[0], context), () => _nextDepthVisitor.Visit(propertyValues[1], context));
     }
 
+    private void WriteDictionaryItem(object item, VisitContext context)
+    {
+        if (ReferenceEquals(item, CollectionItemMarker.TooManyItems))
+        {
+            _codeWriter.WriteTooManyItems(_options.MaxCollectionSize);
+            return;
+        }
+
+        VisitKeyValuePairWriteImplicitly(item, context);
+    }
+
+    private void WriteAnonymousDictionaryItem(object item, string keyName, string valueName, VisitContext context)
+    {
+        if (ReferenceEquals(item, CollectionItemMarker.TooManyItems))
+        {
+            _codeWriter.WriteTooManyItems(_options.MaxCollectionSize);
+            return;
+        }
+
+        VisitKeyValuePairWriteAnonymousType(item, keyName, valueName, context);
+    }
+
+    private IEnumerable GetItems(IEnumerable items)
+    {
+        return _options.MaxCollectionSize == int.MaxValue ? items : TakeItems(items);
+    }
+
+    private IEnumerable<object> TakeItems(IEnumerable items)
+    {
+        var count = 0;
+        foreach (var item in items)
+        {
+            if (count++ == _options.MaxCollectionSize)
+            {
+                yield return CollectionItemMarker.TooManyItems;
+                yield break;
+            }
+
+            yield return item;
+        }
+    }
+
     private void VisitKeyValuePairWriteAnonymousType(object o, string keyName, string valueName, VisitContext context)
     {
         var objectType = o.GetType();
         var propertyValues = objectType.GetProperties().Select(p => ReflectionUtils.GetValue(p, o)).Take(2).ToArray();
         
-        _codeWriter.WriteObjectCreateAndInitialize(new CodeAnonymousTypeInfo(), [],
-            [
-                () => _codeWriter.WriteAssign(() => _codeWriter.WritePropertyReference(keyName, null), () => _nextDepthVisitor.Visit(propertyValues[0], context)),
-                () => _codeWriter.WriteAssign(() => _codeWriter.WritePropertyReference(valueName, null), () => _nextDepthVisitor.Visit(propertyValues[1], context)),
-            ]);
+        _codeWriter.WriteObjectCreateAndInitializeItems(
+            new CodeAnonymousTypeInfo(),
+            [],
+            new[]
+            {
+                new KeyValuePair<string, object>(keyName, propertyValues[0]),
+                new KeyValuePair<string, object>(valueName, propertyValues[1])
+            },
+            initializer =>
+            {
+                var pair = (KeyValuePair<string, object>)initializer;
+                _codeWriter.WriteMemberAssignmentStart(pair.Key);
+                _nextDepthVisitor.Visit(pair.Value, context);
+            });
     }
 }

--- a/src/VarDump/Visitor/KnownObjects/DictionaryVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/DictionaryVisitor.cs
@@ -71,6 +71,12 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
 
     private void VisitSimpleDictionary(IDictionary dict, VisitContext context)
     {
+        if (_options.MaxCollectionSize == int.MaxValue)
+        {
+            VisitSimpleDictionaryStreaming(dict, context);
+            return;
+        }
+
         var items = dict.Cast<object>().Select(item => (Action)(() => VisitKeyValuePairWriteImplicitly(item, context)));
 
         if (_options.MaxCollectionSize < int.MaxValue)
@@ -103,6 +109,33 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
         {
             return () => _codeWriter.WriteObjectCreateAndInitialize(dictionaryTypeInfo, [], initializers);
         }
+    }
+
+    private void VisitSimpleDictionaryStreaming(IDictionary dict, VisitContext context)
+    {
+        var type = dict.GetType();
+        var isImmutableOrFrozen = type.IsPublicImmutableOrFrozenCollection();
+        var dictionaryType = isImmutableOrFrozen
+            ? typeof(Dictionary<,>).MakeGenericType(
+                ReflectionUtils.GetInnerElementType(dict.Keys.GetType()),
+                ReflectionUtils.GetInnerElementType(dict.Values.GetType()))
+            : type;
+
+        void WriteDictionaryCreate() => _codeWriter.WriteDictionaryCreateItems(
+            new CodeCollectionTypeInfo(dictionaryType),
+            dict,
+            key => _nextDepthVisitor.Visit(key, context),
+            value => _nextDepthVisitor.Visit(value, context));
+
+        if (isImmutableOrFrozen)
+        {
+            _codeWriter.WriteMethodInvoke(
+                () => _codeWriter.WriteMethodReference(WriteDictionaryCreate, $"To{type.GetImmutableOrFrozenTypeName()}"),
+                []);
+            return;
+        }
+
+        WriteDictionaryCreate();
     }
 
     private void VisitAnonymousDictionary(IEnumerable dictionary, VisitContext context)

--- a/src/VarDump/Visitor/ObjectDescriptionWriter.cs
+++ b/src/VarDump/Visitor/ObjectDescriptionWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -26,19 +26,29 @@ public sealed class ObjectDescriptionWriter(INextDepthVisitor nextDepthVisitor, 
                 ? () => codeWriter.WriteNamedArgument(ca.Name, () => nextDepthVisitor.Visit(ca.Value, context))
                 : (Action)(() => nextDepthVisitor.Visit(ca.Value, context)));
 
-        var memberInitializers = members
-            .Where(m => (!options.IgnoreNullValues || options.IgnoreNullValues && m.Value != null) &&
-                        (!options.IgnoreDefaultValues ||
-                            ReflectionUtils.GetDefaultValue(m)?.Equals(m.Value) != true))
-            .Select(m => (Action)(() => codeWriter.WriteAssign(
-                () => codeWriter.WritePropertyReference(m.Name, null),
-                () => nextDepthVisitor.Visit(m.Value, context))));
-
-        codeWriter.WriteObjectCreateAndInitialize
-        (
+        codeWriter.WriteObjectCreateAndInitializeItems(
             objectDescription.Type,
             constructorArguments,
-            memberInitializers
-        );
+            FilterMembers(members, options),
+            member =>
+            {
+                var description = (MemberDescription)member;
+                codeWriter.WriteMemberAssignmentStart(description.Name);
+                nextDepthVisitor.Visit(description.Value, context);
+            });
+    }
+
+    private static IEnumerable<MemberDescription> FilterMembers(IEnumerable<MemberDescription> members, DumpOptions options)
+    {
+        foreach (var member in members)
+        {
+            var value = member.Value;
+            if (options.IgnoreNullValues && value == null)
+                continue;
+            if (options.IgnoreDefaultValues && ReflectionUtils.GetDefaultValue(member)?.Equals(value) == true)
+                continue;
+
+            yield return member;
+        }
     }
 }

--- a/src/VarDump/Visitor/ObjectVisitor.cs
+++ b/src/VarDump/Visitor/ObjectVisitor.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using VarDump.CodeDom.Compiler;
+﻿using VarDump.CodeDom.Compiler;
 using VarDump.Collections;
 using VarDump.Extensions;
 using VarDump.Visitor.KnownObjects;
@@ -70,8 +69,7 @@ internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor
 
             var objectType = @object?.GetType();
 
-            var specificVisitor = _knownObjects.Values.FirstOrDefault(v => v.IsSuitableFor(@object, objectType))
-                                  ?? _descriptionBasedVisitor;
+            var specificVisitor = FindSpecificVisitor(@object, objectType);
 
             specificVisitor.Visit(@object, objectType, context);
         }
@@ -79,5 +77,17 @@ internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor
         {
             context.CurrentDepth--;
         }
+    }
+
+    private ISpecificVisitor FindSpecificVisitor(object @object, System.Type objectType)
+    {
+        for (var index = 0; index < _knownObjects.Count; index++)
+        {
+            var visitor = _knownObjects[index].Value;
+            if (visitor.IsSuitableFor(@object, objectType))
+                return visitor;
+        }
+
+        return _descriptionBasedVisitor;
     }
 }

--- a/test/VarDump.Extensions.UnitTests/VarDump.Extensions.UnitTests.csproj
+++ b/test/VarDump.Extensions.UnitTests/VarDump.Extensions.UnitTests.csproj
@@ -1,26 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0;net9.0;net462</TargetFrameworks>
-	<IsPackable>false</IsPackable>
-	<LangVersion>latest</LangVersion>
+    <TargetFrameworks>net10.0;net462</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.13.0" />
-	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-	<PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.0" />
-	<PackageReference Include="xunit" Version="2.9.3" />
-	<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-	 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	 <PrivateAssets>all</PrivateAssets>
-	</PackageReference>
-	<PackageReference Include="coverlet.collector" Version="6.0.4">
-	 <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	 <PrivateAssets>all</PrivateAssets>
-	</PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+     <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+     <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/VarDump.Extensions.UnitTests/VarDumpExtensionsSpec.cs
+++ b/test/VarDump.Extensions.UnitTests/VarDumpExtensionsSpec.cs
@@ -61,7 +61,7 @@ public class VarDumpExtensionsSpec
         VarDumpExtensions.VarDumpFactory = VarDumpFactories.CSharp;
         VarDumpExtensions.DefaultDumpOptions = new DumpOptions
         {
-            UseTypeFullName = true
+            TypeNamePolicy = TypeNamingPolicy.FullName
         };
 
         var result = anonymous.DumpText();

--- a/test/VarDump.UnitTests/ArraySpec.cs
+++ b/test/VarDump.UnitTests/ArraySpec.cs
@@ -134,6 +134,19 @@ public class ArraySpec
     }
 
     [Fact]
+    public void DumpEmptyJaggedArrayCSharp()
+    {
+        int[][] array = [];
+
+        var result = new CSharpDumper().Dump(array);
+
+        Assert.Equal(
+            "var arrayOfArrayOfInt = new int[0][];\n",
+            result,
+            ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
     public void DumpImmutableArrayOfArraysCSharp()
     {
         var array = new[] { new[] { 1 } }.ToImmutableArray();

--- a/test/VarDump.UnitTests/StreamingWriterSpec.cs
+++ b/test/VarDump.UnitTests/StreamingWriterSpec.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace VarDump.UnitTests;
+
+public class StreamingWriterSpec
+{
+    [Fact]
+    public void DumpSingleUseEnumerableCSharp()
+    {
+        var items = new SingleUseEnumerable();
+
+        var result = new CSharpDumper().Dump(items);
+
+        Assert.Equal(
+            """
+            var singleUseEnumerableOfInt = new int[]
+            {
+                1,
+                2,
+                3
+            };
+
+            """, result, ignoreLineEndingDifferences: true);
+        Assert.Equal(1, items.EnumerationCount);
+    }
+
+    [Fact]
+    public void DumpSingleUseEnumerableVisualBasic()
+    {
+        var items = new SingleUseEnumerable();
+
+        var result = new VisualBasicDumper().Dump(items);
+
+        Assert.Equal(
+            """
+            Dim singleUseEnumerableOfInteger = New Integer(){
+                1,
+                2,
+                3
+            }
+
+            """, result, ignoreLineEndingDifferences: true);
+        Assert.Equal(1, items.EnumerationCount);
+    }
+
+    private sealed class SingleUseEnumerable : IEnumerable<int>
+    {
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            if (++EnumerationCount > 1)
+                throw new InvalidOperationException("The source can only be enumerated once.");
+
+            yield return 1;
+            yield return 2;
+            yield return 3;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/test/VarDump.UnitTests/VarDump.UnitTests.csproj
+++ b/test/VarDump.UnitTests/VarDump.UnitTests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.13.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.6.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Refactors the dump-rendering pipeline to stream collection items and object initializers directly. This removes the intermediate per-item `Action` allocations from the hot path while preserving generated C# and Visual Basic output.

## Changes

- Added streaming item/callback APIs to the C# and Visual Basic code writers for arrays, collection expressions, dictionaries, and object/collection initializers.
- Migrated collections, dictionaries, groupings, anonymous objects, and normal object members to the streaming APIs.
- Supports unlimited and `MaxCollectionSize`-capped collections, dictionaries, groupings, and multidimensional arrays; a shared marker writes the truncation indicator.
- Preserves rendering for immutable/frozen and read-only collections, queryables, collection expressions, and empty jagged arrays.
- Caches reflected anonymous-object properties when no custom descriptor pipeline is configured, and replaces LINQ visitor lookup with indexed iteration.
- Removes superseded action-based methods from the internal writer interface and writes member assignments directly.
- Bumps `VarDump` and `VarDump.Extensions` to `2.0.5.0`, updates dependencies, and changes extension-test targets to `net10.0` and `net462`.

## Tests

- Added regression coverage for single-use enumerables in both C# and Visual Basic, confirming exactly one enumeration.
- Added regression coverage for empty jagged C# arrays.
- `dotnet test VarDump.sln --no-restore`
  - Core tests: 216 passed / 4 skipped (`net10.0`); 208 passed / 5 skipped (`net462`)
  - Extension tests: 3 passed on each target
