### PR TITLE
Fix/collection literals and readonly initializers

### DIFF
--- a/.github/workflows/build-nuget-packages.yml
+++ b/.github/workflows/build-nuget-packages.yml
@@ -1,0 +1,53 @@
+name: Build NuGet packages
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  build:
+    name: Build, test, and pack
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore VarDump.slnx
+
+      - name: Build
+        run: dotnet build VarDump.slnx --configuration Release --no-restore -p:GeneratePackageOnBuild=false
+
+      - name: Test
+        run: dotnet test VarDump.slnx --configuration Release --no-build --no-restore -p:GeneratePackageOnBuild=false
+
+      - name: Pack VarDump
+        run: dotnet pack src/VarDump/VarDump.csproj --configuration Release --no-build --no-restore --output artifacts
+
+      - name: Pack VarDump.Extensions
+        run: dotnet pack src/VarDump.Extensions/VarDump.Extensions.csproj --configuration Release --no-build --no-restore --output artifacts
+
+      - name: Upload NuGet packages
+        uses: actions/upload-artifact@v7
+        with:
+          name: vardump-nuget-packages
+          path: |
+            artifacts/*.nupkg
+            artifacts/*.snupkg
+          if-no-files-found: error

--- a/docs/API_GUIDE_DumpOptions.md
+++ b/docs/API_GUIDE_DumpOptions.md
@@ -42,7 +42,7 @@ var text = dumper.Dump(new { Name = "Nick", Age = 23, Tags = new[] { "a", "b" } 
 | `GetPropertiesBindingFlags` | `BindingFlags` | `BindingFlags.Public \| BindingFlags.Instance` | Controls **which properties** are inspected. | Default includes public instance properties only. Add `NonPublic` for private/protected/internal properties, and `Static` for static properties. |
 | `IgnoreDefaultValues` | `bool` | `true` | Skips members equal to type default values. | Set `false` to always include defaults like `0`, `false`, etc. |
 | `IgnoreNullValues` | `bool` | `true` | Skips members with `null` values. | Set `false` to include explicit `null` assignments. |
-| `IgnoreReadonlyProperties` | `bool` | `true` | Skips read-only properties. | Set `false` to include read-only properties in output. |
+| `IgnoreReadonlyProperties` | `bool` | `true` | Skips read-only properties. | In C# initializer mode, get-only collections with an applicable `Add` method are emitted as nested collection initializers. Set `false` to include other read-only properties. |
 | `IndentString` | `string` | four spaces | Indentation text for multiline formatting. | Common values: `"  "` (2 spaces), `"    "` (4 spaces), `"\t"` (tab). |
 | `IntegralNumericFormat` | `string` | `""` | Numeric format string for integral values (`sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`). | VarDump-specific grammar: `<fmt><digits>_<groupSize>` where `<fmt>` is `d/D` (decimal), `b/B` (binary), `x/X` (hex). `digits` and `_groupSize` are optional. |
 | `MaxCollectionSize` | `int` | `int.MaxValue` | Maximum number of items emitted per collection. | Lower value truncates output after limit. |

--- a/src/VarDump.Extensions/VarDump.Extensions.csproj
+++ b/src/VarDump.Extensions/VarDump.Extensions.csproj
@@ -6,13 +6,13 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>VarDump.Extensions</AssemblyName>
-    <AssemblyVersion>2.0.8.0</AssemblyVersion>
-    <FileVersion>2.0.8.0</FileVersion>
+    <AssemblyVersion>2.0.9.0</AssemblyVersion>
+    <FileVersion>2.0.9.0</FileVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>VarDump.Extensions</Title>
-    <Version>2.0.8.0</Version>
+    <Version>2.0.9.0</Version>
     <Description>Extension methods to simplify usage of the VarDump library.</Description>
     <PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/VarDump.Extensions/VarDump.Extensions.csproj
+++ b/src/VarDump.Extensions/VarDump.Extensions.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="VarDump" Version="2.0.8" />
+    <PackageReference Include="VarDump" Version="2.0.9" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/VarDump/CSharpDumper.cs
+++ b/src/VarDump/CSharpDumper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using VarDump.CodeDom.Common;
 using VarDump.CodeDom.Compiler;
 using VarDump.CodeDom.CSharp;
@@ -88,27 +87,31 @@ public sealed class CSharpDumper : IDumper
 
         var objectVisitor = new ObjectVisitor(_options, codeWriter);
 
+        var canEmitCollectionExpressionDirectly = _options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
+                                                  && obj != null
+                                                  && CollectionExpressionUtils.CanEmitDirectly(obj, obj.GetType());
+
         if (_options.GenerateVariableInitializer)
         {
-            CodeTypeInfo declarationType = new CodeVarTypeInfo();
-
-            if (_options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
-                && obj is System.Collections.IEnumerable)
-            {
-                var objectType = obj.GetType();
-                var queryableType = objectType.GetInterfaces()
-                    .FirstOrDefault(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IQueryable<>));
-
-                if(queryableType == null && !objectType.ContainsAnonymousType())
-                    declarationType = objectType;
-            }
+            var declarationType = canEmitCollectionExpressionDirectly
+                ? new CodeTypeInfo(obj.GetType())
+                : new CodeVarTypeInfo();
 
             codeWriter.WriteVariableDeclarationStatement(declarationType,
-                obj != null ? ReflectionUtils.ComposeCSharpVariableName(obj.GetType()) : "nullValue", () => objectVisitor.Visit(obj));
+                obj != null
+                    ? ReflectionUtils.ComposeCSharpVariableName(obj.GetType())
+                    : "nullValue", () => objectVisitor.Visit(obj));
         }
         else
         {
-            objectVisitor.Visit(obj);
+            if (canEmitCollectionExpressionDirectly)
+            {
+                codeWriter.WriteCast(new CodeTypeInfo(obj.GetType()), () => objectVisitor.Visit(obj));
+            }
+            else
+            {
+                objectVisitor.Visit(obj);
+            }
         }
     }
 }

--- a/src/VarDump/CodeDom/CSharp/CSharpCodeWriter.cs
+++ b/src/VarDump/CodeDom/CSharp/CSharpCodeWriter.cs
@@ -30,6 +30,7 @@ internal sealed class CSharpCodeWriter : ICodeWriter
 
     public string NullToken => "null";
     public bool SupportsCollectionExpression => true;
+    public bool SupportsReadonlyCollectionInitializers => true;
 
     public CSharpCodeWriter(TextWriter w, CodeWriterOptions o)
     {
@@ -269,7 +270,7 @@ internal sealed class CSharpCodeWriter : ICodeWriter
         var enumerator = items.GetEnumerator();
         using var enumeratorDisposable = enumerator as IDisposable;
         var hasItems = enumerator.MoveNext();
-        
+
         if (singleLine)
         {
             _output.Write("{ ");
@@ -319,10 +320,17 @@ internal sealed class CSharpCodeWriter : ICodeWriter
         action();
     }
 
-    public void WriteMemberAssignmentStart(string memberName)
+    public void WriteMemberAssignmentStart(string memberName, bool valueOnNewLine = false)
     {
         WritePropertyReference(memberName, null);
-        _output.Write(" = ");
+        if (valueOnNewLine)
+        {
+            _output.WriteLine(" =");
+        }
+        else
+        {
+            _output.Write(" = ");
+        }
     }
 
     public void WriteDefaultValue(CodeTypeInfo typeInfo)

--- a/src/VarDump/CodeDom/Compiler/ICodeWriter.cs
+++ b/src/VarDump/CodeDom/Compiler/ICodeWriter.cs
@@ -10,13 +10,18 @@ public interface ICodeWriter
     int Indent { get; set; }
     bool SupportsCollectionExpression { get; }
 
+    /// <summary>
+    /// Indicates whether the target language can populate a get-only collection property from an object initializer.
+    /// </summary>
+    bool SupportsReadonlyCollectionInitializers { get; }
+
     void WriteArrayCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem, bool singleLine, int size = 0);
     void WriteDictionaryCreateItems(CodeTypeInfo typeInfo, IEnumerable items, Action<object> writeItem);
     void WriteCast(CodeTypeInfo typeInfo, Action action);
 
     void WriteArrayDimensionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false);
     void WriteCollectionExpressionItems(IEnumerable items, Action<object> writeItem, bool singleLine = false);
-    void WriteMemberAssignmentStart(string memberName);
+    void WriteMemberAssignmentStart(string memberName, bool valueOnNewLine = false);
 
     void WriteImplicitKeyValuePairCreate(Action keyAction, Action valueAction);
 

--- a/src/VarDump/CodeDom/VisualBasic/VisualBasicCodeWriter.cs
+++ b/src/VarDump/CodeDom/VisualBasic/VisualBasicCodeWriter.cs
@@ -30,6 +30,7 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
 
     public string NullToken => "Nothing";
     public bool SupportsCollectionExpression => false;
+    public bool SupportsReadonlyCollectionInitializers => false;
 
 
     public VisualBasicCodeWriter(TextWriter w, CodeWriterOptions o)
@@ -192,10 +193,17 @@ internal sealed class VisualBasicCodeWriter : ICodeWriter
         value();
     }
 
-    public void WriteMemberAssignmentStart(string memberName)
+    public void WriteMemberAssignmentStart(string memberName, bool valueOnNewLine = false)
     {
         WritePropertyReference(memberName, null);
-        _output.Write(" = ");
+        if (valueOnNewLine)
+        {
+            _output.WriteLine(" = _");
+        }
+        else
+        {
+            _output.Write(" = ");
+        }
     }
 
     public void WriteDefaultValue(CodeTypeInfo typeInfo)

--- a/src/VarDump/Extensions/CodeWriterExtensions.cs
+++ b/src/VarDump/Extensions/CodeWriterExtensions.cs
@@ -20,9 +20,11 @@ public static class CodeWriterExtensions
         codeWriter.WriteComment("Circular reference detected", true);
     }
 
-    public static void WriteTooManyItems(this ICodeWriter codeWriter, int maxCollectionSize)
+    public static void WriteTooManyItems(this ICodeWriter codeWriter, int maxCollectionSize,
+        bool terminateLine = false)
     {
-        codeWriter.WriteComment($"Too many items (> {maxCollectionSize}). Consider increasing the {nameof(DumpOptions.MaxCollectionSize)} option.", noNewLine: true);
+        codeWriter.WriteComment($"Too many items (> {maxCollectionSize}). Consider increasing the {nameof(DumpOptions.MaxCollectionSize)} option.",
+            noNewLine: !terminateLine);
     }
 
     public static void WriteMaxDepthExpression(this ICodeWriter codeWriter, object @object)

--- a/src/VarDump/Utils/CollectionExpressionUtils.cs
+++ b/src/VarDump/Utils/CollectionExpressionUtils.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+namespace VarDump.Utils;
+
+internal static class CollectionExpressionUtils
+{
+    private const string CollectionBuilderAttributeName =
+        "System.Runtime.CompilerServices.CollectionBuilderAttribute";
+
+    public static bool CanEmitDirectly(object collection, Type collectionType)
+    {
+        if (collection is not IEnumerable || collection is IDictionary)
+        {
+            return false;
+        }
+
+        if (collectionType.ContainsAnonymousType())
+        {
+            return false;
+        }
+
+        var elementType = ReflectionUtils.GetInnerElementType(collectionType);
+        if (elementType.IsGrouping())
+        {
+            return false;
+        }
+
+        if (collectionType.IsArray)
+        {
+            return ((Array)collection).Rank == 1;
+        }
+
+        if (!collectionType.IsVisible || collectionType.IsReadonlyCollection())
+        {
+            return false;
+        }
+
+        if (HasCollectionBuilder(collectionType))
+        {
+            return true;
+        }
+
+        return HasParameterlessConstructor(collectionType)
+               && HasApplicableAddMethod(collectionType, elementType);
+    }
+
+    private static bool HasCollectionBuilder(Type type)
+    {
+        return type.GetCustomAttributesData()
+            .Any(attribute => attribute.AttributeType.FullName == CollectionBuilderAttributeName);
+    }
+
+    private static bool HasParameterlessConstructor(Type type)
+    {
+        return type.IsValueType || type.GetConstructors()
+            .Any(constructor => constructor.GetParameters()
+                .All(parameter => parameter.IsOptional
+                                  || parameter.IsDefined(typeof(ParamArrayAttribute), inherit: false)));
+    }
+
+    private static bool HasApplicableAddMethod(Type type, Type elementType)
+    {
+        return type.GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(method => method.Name == "Add")
+            .Select(method => method.GetParameters())
+            .Any(parameters => parameters.Length == 1
+                               && parameters[0].ParameterType.IsAssignableFrom(elementType));
+    }
+}

--- a/src/VarDump/Utils/ReflectionUtils.cs
+++ b/src/VarDump/Utils/ReflectionUtils.cs
@@ -234,6 +234,30 @@ internal static class ReflectionUtils
         return hasICollection;
     }
 
+    public static bool CanPopulateCollectionInitializer(this Type type)
+    {
+        if (!typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            return false;
+        }
+
+        var isDictionary = typeof(IDictionary).IsAssignableFrom(type)
+                           || type.GetInterfaces().Concat([type])
+                               .Any(candidate => candidate.IsGenericType
+                                                 && candidate.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+        return HasCollectionInitializerAddMethod(type, isDictionary ? 2 : 1);
+    }
+
+    private static bool HasCollectionInitializerAddMethod(Type type, int addParameterCount)
+    {
+        var types = type.IsInterface ? type.GetInterfaces().Concat([type]) : [type];
+
+        return types.SelectMany(candidate => candidate.GetMethods(BindingFlags.Instance | BindingFlags.Public))
+            .Any(method => method.Name == "Add"
+                           && method.GetParameters().Length == addParameterCount);
+    }
+
     public static bool IsPublicImmutableOrFrozenCollection(this Type type)
     {
         var typeFullName = type.FullName ?? "";

--- a/src/VarDump/VarDump.csproj
+++ b/src/VarDump/VarDump.csproj
@@ -4,13 +4,13 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>VarDump</AssemblyName>
-    <AssemblyVersion>2.0.8.0</AssemblyVersion>
-    <FileVersion>2.0.8.0</FileVersion>
+    <AssemblyVersion>2.0.9.0</AssemblyVersion>
+    <FileVersion>2.0.9.0</FileVersion>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2023 - $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>VarDump</Title>
-    <Version>2.0.8.0</Version>
+    <Version>2.0.9.0</Version>
     <Description>VarDump is a utility for serialization runtime objects to C# and Visual Basic string.</Description>
     <PackageProjectUrl>https://github.com/ycherkes/VarDump</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/VarDump/Visitor/DescriptionBasedVisitor.cs
+++ b/src/VarDump/Visitor/DescriptionBasedVisitor.cs
@@ -21,7 +21,11 @@ internal sealed class DescriptionBasedVisitor : ISpecificVisitor
         _options = options;
 
         _objectDescriptor = new CachingObjectPropertiesDescriptor(
-            new ObjectPropertiesDescriptor(options.GetPropertiesBindingFlags, options.IgnoreReadonlyProperties));
+            new ObjectPropertiesDescriptor(
+                options.GetPropertiesBindingFlags,
+                options.IgnoreReadonlyProperties,
+                includeReadonlyCollectionInitializers: codeWriter.SupportsReadonlyCollectionInitializers
+                                                       && options.CollectionLiteralStyle == CollectionLiteralStyle.Initializer));
 
         if (options.GetFieldsBindingFlags != null)
         {

--- a/src/VarDump/Visitor/Descriptors/Implementation/ObjectPropertiesDescriptor.cs
+++ b/src/VarDump/Visitor/Descriptors/Implementation/ObjectPropertiesDescriptor.cs
@@ -6,7 +6,10 @@ using VarDump.Utils;
 
 namespace VarDump.Visitor.Descriptors.Implementation;
 
-internal sealed class ObjectPropertiesDescriptor(BindingFlags getPropertiesBindingFlags, bool writablePropertiesOnly)
+internal sealed class ObjectPropertiesDescriptor(
+    BindingFlags getPropertiesBindingFlags,
+    bool writablePropertiesOnly,
+    bool includeReadonlyCollectionInitializers = false)
     : IObjectDescriptor
 {
     public IObjectDescription GetObjectDescription(object @object, Type objectType)
@@ -45,8 +48,12 @@ internal sealed class ObjectPropertiesDescriptor(BindingFlags getPropertiesBindi
 
         foreach (var property in objectType.GetProperties(getPropertiesBindingFlags))
         {
+            var canWrite = property.CanWrite && MatchesAccessibility(property.SetMethod, getPropertiesBindingFlags);
+            var canPopulate = includeReadonlyCollectionInitializers
+                              && property.PropertyType.CanPopulateCollectionInitializer();
+
             if (!property.CanRead ||
-                ((property.CanWrite && MatchesAccessibility(property.SetMethod, getPropertiesBindingFlags)) || !writablePropertiesOnly) == false ||
+                (canWrite || canPopulate || !writablePropertiesOnly) == false ||
                 ReflectionUtils.IsIndexer(property))
             {
                 continue;
@@ -56,7 +63,7 @@ internal sealed class ObjectPropertiesDescriptor(BindingFlags getPropertiesBindi
                 property,
                 property.Name,
                 property.PropertyType,
-                property.CanWrite,
+                canWrite,
                 property.GetCustomAttribute<DefaultValueAttribute>()?.Value));
         }
 

--- a/src/VarDump/Visitor/DumpOptions.cs
+++ b/src/VarDump/Visitor/DumpOptions.cs
@@ -64,6 +64,8 @@ public class DumpOptions
 
     /// <summary>
     /// Ignore readonly properties when dumping, default is <c>true</c>.
+    /// In C# initializer mode, get-only collections with an applicable <c>Add</c> method are emitted
+    /// as nested collection initializers because they can be populated without assigning the property.
     /// </summary>
     public bool IgnoreReadonlyProperties { get; set; } = true;
 

--- a/src/VarDump/Visitor/ICollectionInitializerBodyDispatcher.cs
+++ b/src/VarDump/Visitor/ICollectionInitializerBodyDispatcher.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace VarDump.Visitor;
+
+/// <summary>
+/// Allows <see cref="ObjectDescriptionWriter"/> to request a collection-initializer body without
+/// knowing how <see cref="ObjectVisitor"/> selects the visitor for the runtime value. This keeps
+/// the special rendering mode explicit instead of storing transient state in <see cref="VisitContext"/>.
+/// </summary>
+internal interface ICollectionInitializerBodyDispatcher
+{
+    bool TryWriteCollectionInitializerBody(object value, VisitContext context);
+}
+
+/// <summary>
+/// Identifies visitors that can emit only the braced initializer portion of a collection value.
+/// The dispatcher uses this separate contract because an ordinary visit emits a complete value
+/// expression, which is invalid for a get-only property populated through an <c>Add</c> initializer.
+/// </summary>
+internal interface ICollectionInitializerBodyWriter
+{
+    void WriteCollectionInitializerBody(object value, Type valueType, VisitContext context);
+}

--- a/src/VarDump/Visitor/KnownObjects/CollectionVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/CollectionVisitor.cs
@@ -11,7 +11,7 @@ using VarDump.Visitor.Format;
 
 namespace VarDump.Visitor.KnownObjects;
 
-internal sealed class CollectionVisitor : IKnownObjectVisitor
+internal sealed class CollectionVisitor : IKnownObjectVisitor, ICollectionInitializerBodyWriter
 {
     private readonly INextDepthVisitor _nextDepthVisitor;
     private readonly ICodeWriter _codeWriter;
@@ -76,6 +76,32 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         }
     }
 
+    public void WriteCollectionInitializerBody(object value, Type valueType, VisitContext context)
+    {
+        if (!context.TryAddVisited(value))
+        {
+            _codeWriter.WriteCircularReferenceDetected();
+            return;
+        }
+
+        try
+        {
+            var collection = (IEnumerable)value;
+            var elementType = ReflectionUtils.GetInnerElementType(valueType);
+            var items = GetItems(collection);
+            var singleLine = typeof(string) != elementType
+                             && ReflectionUtils.IsPrimitive(elementType)
+                             && _options.PrimitiveCollectionLayout == CollectionLayout.SingleLine;
+
+            _codeWriter.WriteArrayDimensionItems(items,
+                item => WriteCollectionItem(item, context, singleLine), singleLine);
+        }
+        finally
+        {
+            context.RemoveVisited(value);
+        }
+    }
+
     private void VisitGroupingCollection(IEnumerable collection, VisitContext context)
     {
         var type = collection.GetType();
@@ -134,6 +160,10 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
         var isImmutableOrFrozen = type.IsPublicImmutableOrFrozenCollection();
         var isCollection = IsCollection(enumerable);
+        var useCollectionExpression = _options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
+                                      && _codeWriter.SupportsCollectionExpression;
+        var canEmitCollectionExpressionDirectly = useCollectionExpression
+                                                  && CollectionExpressionUtils.CanEmitDirectly(enumerable, type);
 
         var singleLine = typeof(string) != elementType
                          && ReflectionUtils.IsPrimitive(elementType)
@@ -152,16 +182,33 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
             var arrayType = isImmutableOrFrozen || !type.IsPublic || isQueryable ? elementType.MakeArrayType() : type;
 
             void WriteArrayCreate() => _codeWriter.WriteArrayCreateItems(
-                arrayType, items, item => WriteArrayItem(item, context), singleLine);
+                arrayType, items, item => WriteArrayItem(item, context, singleLine), singleLine);
+
+            void WriteArrayCollectionExpression() => _codeWriter.WriteCollectionExpressionItems(
+                items, item => WriteArrayItem(item, context, singleLine), singleLine);
+
+            void WriteTypedArrayCollectionExpression() =>
+                _codeWriter.WriteCast(arrayType, WriteArrayCollectionExpression);
+
+            void WriteStaticCollectionConversion(Type conversionType, string methodName) =>
+                _codeWriter.WriteMethodInvoke(
+                    () => _codeWriter.WriteMethodReference(
+                        () => _codeWriter.WriteType(conversionType), methodName, elementType),
+                    [WriteArrayCollectionExpression]);
 
             void WriteArrayOrCollectionExpression()
             {
-                if (type.IsArray
-                    && ((Array)enumerable).Rank == 1
-                    && _options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
-                    && _codeWriter.SupportsCollectionExpression)
+                if (canEmitCollectionExpressionDirectly)
                 {
-                    _codeWriter.WriteCollectionExpressionItems(items, item => WriteArrayItem(item, context), singleLine);
+                    WriteArrayCollectionExpression();
+                    return;
+                }
+
+                if (useCollectionExpression
+                    && !type.IsArray
+                    && (!type.IsPublic || isQueryable))
+                {
+                    WriteTypedArrayCollectionExpression();
                     return;
                 }
 
@@ -170,13 +217,37 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
             if (isImmutableOrFrozen)
             {
-                _codeWriter.WriteMethodInvoke(() =>
-                     _codeWriter.WriteMethodReference(WriteArrayCreate, $"To{type.GetImmutableOrFrozenTypeName()}"), []);
+                if (canEmitCollectionExpressionDirectly)
+                {
+                    WriteArrayCollectionExpression();
+                }
+                else
+                {
+                    var methodName = $"To{type.GetImmutableOrFrozenTypeName()}";
+                    var conversionType = type.Assembly.GetType($"{type.Namespace}.{type.GetImmutableOrFrozenTypeName()}");
+
+                    if (useCollectionExpression && conversionType != null)
+                    {
+                        WriteStaticCollectionConversion(conversionType, methodName);
+                    }
+                    else
+                    {
+                        _codeWriter.WriteMethodInvoke(() =>
+                            _codeWriter.WriteMethodReference(WriteArrayCreate, methodName), []);
+                    }
+                }
             }
             else if (isQueryable)
             {
-                _codeWriter.WriteMethodInvoke(() => 
-                    _codeWriter.WriteMethodReference(WriteArrayCreate, "AsQueryable"), []);
+                if (useCollectionExpression)
+                {
+                    WriteStaticCollectionConversion(typeof(Queryable), "AsQueryable");
+                }
+                else
+                {
+                    _codeWriter.WriteMethodInvoke(() =>
+                        _codeWriter.WriteMethodReference(WriteArrayCreate, "AsQueryable"), []);
+                }
             }
             else
             {
@@ -190,6 +261,17 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         {
             var typeInfo =
                 new CodeCollectionTypeInfo(typeof(List<>).MakeGenericType(elementType));
+
+            if (useCollectionExpression)
+            {
+                _codeWriter.WriteObjectCreate(type,
+                [
+                    () => _codeWriter.WriteCollectionExpressionItems(items,
+                        item => WriteCollectionItem(item, context, singleLine), singleLine)
+                ]);
+
+                return;
+            }
 
             var createAction = ResolveCollectionCreateAction(typeInfo, items, singleLine);
 
@@ -205,15 +287,14 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
 
         Action ResolveCollectionCreateAction(CodeTypeInfo collectionType, IEnumerable initializers, bool useSingleLine)
         {
-            if (_options.CollectionLiteralStyle == CollectionLiteralStyle.Expression
-                && _codeWriter.SupportsCollectionExpression)
+            if (canEmitCollectionExpressionDirectly)
             {
                 return () => _codeWriter.WriteCollectionExpressionItems(initializers,
-                    item => WriteCollectionItem(item, context), useSingleLine);
+                    item => WriteCollectionItem(item, context, useSingleLine), useSingleLine);
             }
 
             return () => _codeWriter.WriteObjectCreateAndInitializeItems(collectionType, [], initializers,
-                item => WriteCollectionItem(item, context), useSingleLine);
+                item => WriteCollectionItem(item, context, useSingleLine), useSingleLine);
         }
     }
 
@@ -303,23 +384,23 @@ internal sealed class CollectionVisitor : IKnownObjectVisitor
         return new KeyValuePair<object, IEnumerable>(fieldValues[0], (IEnumerable)fieldValues[1]);
     }
 
-    private void WriteArrayItem(object item, VisitContext context)
+    private void WriteArrayItem(object item, VisitContext context, bool singleLine = false)
     {
         if (item is ArrayDimension dimension)
         {
             _codeWriter.WriteArrayDimensionItems(dimension.Items,
-                nestedItem => WriteArrayItem(nestedItem, context), dimension.SingleLine);
+                nestedItem => WriteArrayItem(nestedItem, context, dimension.SingleLine), dimension.SingleLine);
             return;
         }
 
-        WriteCollectionItem(item, context);
+        WriteCollectionItem(item, context, singleLine);
     }
 
-    private void WriteCollectionItem(object item, VisitContext context)
+    private void WriteCollectionItem(object item, VisitContext context, bool singleLine = false)
     {
         if (ReferenceEquals(item, CollectionItemMarker.TooManyItems))
         {
-            _codeWriter.WriteTooManyItems(_options.MaxCollectionSize);
+            _codeWriter.WriteTooManyItems(_options.MaxCollectionSize, terminateLine: singleLine);
             return;
         }
 

--- a/src/VarDump/Visitor/KnownObjects/DictionaryVisitor.cs
+++ b/src/VarDump/Visitor/KnownObjects/DictionaryVisitor.cs
@@ -9,7 +9,7 @@ using VarDump.Utils;
 
 namespace VarDump.Visitor.KnownObjects;
 
-internal sealed class DictionaryVisitor : IKnownObjectVisitor
+internal sealed class DictionaryVisitor : IKnownObjectVisitor, ICollectionInitializerBodyWriter
 {
     private readonly INextDepthVisitor _nextDepthVisitor;
     private readonly ICodeWriter _codeWriter;
@@ -66,6 +66,26 @@ internal sealed class DictionaryVisitor : IKnownObjectVisitor
         finally
         {
             context.RemoveVisited(dict);
+        }
+    }
+
+    public void WriteCollectionInitializerBody(object value, Type valueType, VisitContext context)
+    {
+        var dictionary = (IDictionary)value;
+        if (!context.TryAddVisited(dictionary))
+        {
+            _codeWriter.WriteCircularReferenceDetected();
+            return;
+        }
+
+        try
+        {
+            _codeWriter.WriteArrayDimensionItems(GetItems(dictionary),
+                item => WriteDictionaryItem(item, context));
+        }
+        finally
+        {
+            context.RemoveVisited(dictionary);
         }
     }
 

--- a/src/VarDump/Visitor/ObjectDescriptionWriter.cs
+++ b/src/VarDump/Visitor/ObjectDescriptionWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -33,7 +34,20 @@ public sealed class ObjectDescriptionWriter(INextDepthVisitor nextDepthVisitor, 
             member =>
             {
                 var description = (MemberDescription)member;
-                codeWriter.WriteMemberAssignmentStart(description.Name);
+                var writeCollectionInitializerOnly = codeWriter.SupportsReadonlyCollectionInitializers
+                                                     && description is PropertyDescription { CanWrite: false }
+                                                     && description.Value is IEnumerable
+                                                     && description.Type.CanPopulateCollectionInitializer();
+                codeWriter.WriteMemberAssignmentStart(description.Name,
+                    valueOnNewLine: writeCollectionInitializerOnly);
+
+                if (writeCollectionInitializerOnly
+                    && nextDepthVisitor is ICollectionInitializerBodyDispatcher collectionInitializerBodyDispatcher
+                    && collectionInitializerBodyDispatcher.TryWriteCollectionInitializerBody(description.Value, context))
+                {
+                    return;
+                }
+
                 nextDepthVisitor.Visit(description.Value, context);
             });
     }

--- a/src/VarDump/Visitor/ObjectVisitor.cs
+++ b/src/VarDump/Visitor/ObjectVisitor.cs
@@ -5,7 +5,7 @@ using VarDump.Visitor.KnownObjects;
 
 namespace VarDump.Visitor;
 
-internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor
+internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor, ICollectionInitializerBodyDispatcher
 {
     private readonly ICodeWriter _codeWriter;
     private readonly IKnownObjectsCollection _knownObjects;
@@ -72,6 +72,33 @@ internal sealed class ObjectVisitor : IObjectVisitor, INextDepthVisitor
             var specificVisitor = FindSpecificVisitor(@object, objectType);
 
             specificVisitor.Visit(@object, objectType, context);
+        }
+        finally
+        {
+            context.CurrentDepth--;
+        }
+    }
+
+    public bool TryWriteCollectionInitializerBody(object value, VisitContext context)
+    {
+        if (context.IsMaxDepth())
+        {
+            return false;
+        }
+
+        try
+        {
+            context.CurrentDepth++;
+
+            var valueType = value?.GetType();
+            var specificVisitor = FindSpecificVisitor(value, valueType);
+            if (specificVisitor is not ICollectionInitializerBodyWriter collectionInitializerBodyWriter)
+            {
+                return false;
+            }
+
+            collectionInitializerBodyWriter.WriteCollectionInitializerBody(value, valueType, context);
+            return true;
         }
         finally
         {

--- a/test/VarDump.UnitTests/CollectionExpressionSpec.cs
+++ b/test/VarDump.UnitTests/CollectionExpressionSpec.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using VarDump.UnitTests.TestModel;
+using VarDump.Visitor;
+using VarDump.Visitor.Format;
+using Xunit;
+
+namespace VarDump.UnitTests;
+
+public class CollectionExpressionSpec
+{
+    private static readonly DumpOptions ExpressionOptions = new()
+    {
+        CollectionLiteralStyle = CollectionLiteralStyle.Expression,
+        PrimitiveCollectionLayout = CollectionLayout.SingleLine
+    };
+
+    [Fact]
+    public void EmitsDirectCollectionExpressionsForSupportedTargetTypes()
+    {
+        var cases = new (string Name, object Value, string Expected)[]
+        {
+            ("empty array", Array.Empty<int>(), "int[] arrayOfInt = [];"),
+            ("array", new[] { 1, 2 }, "int[] arrayOfInt = [1, 2];"),
+            ("list", new List<int> { 1, 2 }, "List<int> listOfInt = [1, 2];"),
+            ("set", new HashSet<int> { 1, 2 }, "HashSet<int> hashSetOfInt = [1, 2];"),
+            ("immutable array", ImmutableArray.Create(1, 2),
+                "ImmutableArray<int> immutableArrayOfInt = [1, 2];"),
+            ("immutable list", ImmutableList.Create(1, 2),
+                "ImmutableList<int> immutableListOfInt = [1, 2];")
+        };
+
+        foreach (var testCase in cases)
+        {
+            var result = new CSharpDumper(ExpressionOptions).Dump(testCase.Value);
+
+            Assert.Equal(testCase.Expected + Environment.NewLine, result,
+                ignoreLineEndingDifferences: true);
+            AssertCompiles(testCase.Name, result);
+        }
+    }
+
+    [Fact]
+    public void EmitsExpressionForConstructibleNonGenericCollection()
+    {
+        var collection = new ArrayList { 1, "two" };
+
+        var result = new CSharpDumper(ExpressionOptions).Dump(collection);
+
+        Assert.Contains("ArrayList arrayListOfObject = ", result);
+        Assert.DoesNotContain("new ArrayList", result);
+        AssertCompiles("non-generic collection", result);
+    }
+
+    [Fact]
+    public void EmitsExpressionWhenParameterlessConstructionUsesOptionalArguments()
+    {
+        var collection = new OptionalConstructorCollection { 1, 2 };
+
+        var result = new CSharpDumper(ExpressionOptions).Dump(collection);
+
+        Assert.Contains("OptionalConstructorCollection optionalConstructorCollectionOfInt = [1, 2]", result);
+        Assert.DoesNotContain("new OptionalConstructorCollection", result);
+        AssertCompiles("optional constructor collection", result);
+    }
+
+    [Fact]
+    public void SuppliesTargetsForExpressionsUsedByConversionMethods()
+    {
+        var cases = new (string Name, object Value, string ExpectedFragment)[]
+        {
+            ("read-only collection", new List<int> { 1, 2 }.AsReadOnly(),
+                "new ReadOnlyCollection<int>([1, 2])"),
+            ("enumerable", Enumerable.Range(1, 2), "(int[])[1, 2]"),
+            ("queryable", Queryable.AsQueryable([1, 2]), "Queryable.AsQueryable<int>([1, 2])")
+        };
+
+        foreach (var testCase in cases)
+        {
+            var result = new CSharpDumper(ExpressionOptions).Dump(testCase.Value);
+
+            Assert.Contains(testCase.ExpectedFragment, result);
+            AssertCompiles(testCase.Name, result);
+        }
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void SuppliesAnArrayTargetBeforeCreatingFrozenCollection()
+    {
+        var collection = new[] { 1, 2 }.ToFrozenSet();
+
+        var result = new CSharpDumper(ExpressionOptions).Dump(collection);
+
+        Assert.Contains("FrozenSet.ToFrozenSet<int>([1, 2])", result);
+        AssertCompiles("frozen set", result);
+    }
+#endif
+
+    [Fact]
+    public void UsesExpressionForNonPublicEnumerableArrayFallback()
+    {
+        var collection = new CatNonPublicCollection
+        {
+            new Cat { Name = "Milo", Age = 3 }
+        };
+
+        var result = new CSharpDumper(ExpressionOptions).Dump(collection);
+
+        Assert.Contains("var catNonPublicCollectionOfObject = (object[])", result);
+        Assert.Contains("[", result);
+        Assert.DoesNotContain("new object[]", result);
+        AssertCompiles("non-public enumerable", result);
+    }
+
+    [Fact]
+    public void KeepsInitializerForTargetsWithoutACollectionExpressionConversion()
+    {
+        var customCollection = new CatPublicCollection
+        {
+            new Cat { Name = "Milo", Age = 3 }
+        };
+        var dictionary = new Dictionary<string, int> { { "one", 1 } };
+        var multidimensionalArray = new[,] { { 1, 2 } };
+
+        var customResult = new CSharpDumper(ExpressionOptions).Dump(customCollection);
+        var dictionaryResult = new CSharpDumper(ExpressionOptions).Dump(dictionary);
+        var multidimensionalResult = new CSharpDumper(ExpressionOptions).Dump(multidimensionalArray);
+
+        Assert.Contains("new CatPublicCollection", customResult);
+        Assert.Contains("new Dictionary<string, int>", dictionaryResult);
+        Assert.Contains("new int[,]", multidimensionalResult);
+        AssertCompiles("custom non-generic collection", customResult);
+        AssertCompiles("dictionary", dictionaryResult);
+        AssertCompiles("multidimensional array", multidimensionalResult);
+    }
+
+    [Fact]
+    public void KeepsInitializerForAnonymousAndGroupingCollections()
+    {
+        var anonymousCollection = new[] { new { Value = 1 } };
+        var groupingCollection = new[] { 1, 2 }.GroupBy(value => value).ToArray();
+
+        var anonymousResult = new CSharpDumper(ExpressionOptions).Dump(anonymousCollection);
+        var groupingResult = new CSharpDumper(ExpressionOptions).Dump(groupingCollection);
+
+        Assert.Contains("new []", anonymousResult);
+        Assert.Contains("new []", groupingResult);
+        AssertCompiles("anonymous collection", anonymousResult);
+        AssertCompiles("grouping collection", groupingResult);
+    }
+
+    [Fact]
+    public void EmitsValidExpressionsForNestedAndTruncatedCollections()
+    {
+        var jaggedArray = new[] { new[] { 1, 2 } };
+        var owner = new CatOwner
+        {
+            Cats = [new Cat { Name = "Milo", Age = 3 }]
+        };
+        var truncated = new List<int> { 1, 2, 3 };
+
+        var jaggedResult = new CSharpDumper(ExpressionOptions).Dump(jaggedArray);
+        var ownerResult = new CSharpDumper(ExpressionOptions).Dump(owner);
+        var truncatedResult = new CSharpDumper(new DumpOptions
+        {
+            CollectionLiteralStyle = CollectionLiteralStyle.Expression,
+            PrimitiveCollectionLayout = CollectionLayout.SingleLine,
+            MaxCollectionSize = 2
+        }).Dump(truncated);
+
+        Assert.DoesNotContain("new int[]", jaggedResult);
+        Assert.Contains("Cats = ", ownerResult);
+        Assert.DoesNotContain("Cats = new", ownerResult);
+        Assert.Contains("Too many items", truncatedResult);
+        AssertCompiles("jagged array", jaggedResult);
+        AssertCompiles("collection property", ownerResult);
+        AssertCompiles("truncated collection", truncatedResult);
+    }
+
+    [Fact]
+    public void SuppliesTargetWhenVariableInitializerIsDisabled()
+    {
+        var result = new CSharpDumper(new DumpOptions
+        {
+            CollectionLiteralStyle = CollectionLiteralStyle.Expression,
+            PrimitiveCollectionLayout = CollectionLayout.SingleLine,
+            GenerateVariableInitializer = false
+        }).Dump(new List<int> { 1, 2 });
+
+        Assert.Equal("(List<int>)[1, 2]", result);
+        AssertExpressionCompiles("initializer-free collection", result);
+    }
+
+    private static void AssertCompiles(string caseName, string statement)
+    {
+#if NET8_0_OR_GREATER
+        const string frozenCollectionsUsing = "using System.Collections.Frozen;";
+#else
+        const string frozenCollectionsUsing = "";
+#endif
+        var source = $$"""
+                       using System;
+                       using System.Collections;
+                       using System.Collections.Generic;
+                       using System.Collections.Immutable;
+                       using System.Collections.ObjectModel;
+                       using System.Linq;
+                       {{frozenCollectionsUsing}}
+                       using VarDump.UnitTests;
+                       using VarDump.UnitTests.TestModel;
+
+                       public static class GeneratedCollectionExpression
+                       {
+                           public static void Create()
+                           {
+                       {{statement}}
+                           }
+                       }
+                       """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source,
+            new CSharpParseOptions(LanguageVersion.Latest));
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location))
+            .GroupBy(assembly => assembly.Location, StringComparer.OrdinalIgnoreCase)
+            .Select(group => MetadataReference.CreateFromFile(group.Key));
+        var compilation = CSharpCompilation.Create(
+            "GeneratedCollectionExpression_" + Guid.NewGuid().ToString("N"),
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var errors = compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        Assert.True(errors.Length == 0,
+            $"Generated code for '{caseName}' did not compile:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, errors.Select(error => error.ToString())) +
+            $"{Environment.NewLine}{Environment.NewLine}{source}");
+    }
+
+    private static void AssertExpressionCompiles(string caseName, string expression)
+    {
+        var statement = $"object result = {expression};";
+        AssertCompiles(caseName, statement);
+    }
+
+}
+
+public sealed class OptionalConstructorCollection(int capacity = 0) : List<int>(capacity);

--- a/test/VarDump.UnitTests/EnumerableQuerySpec.cs
+++ b/test/VarDump.UnitTests/EnumerableQuerySpec.cs
@@ -35,14 +35,13 @@ public class EnumerableQuerySpec
 
         var result = dumper.Dump(query);
 
-        // Queryable must be output as an initializer regardless of the CollectionLiteralStyle
         Assert.Equal(
             """
-            var enumerableQueryOfInt = new int[]
-            {
-                5,
-                6
-            }.AsQueryable();
+            var enumerableQueryOfInt = Queryable.AsQueryable<int>(
+                [
+                    5,
+                    6
+                ]);
 
             """, result, ignoreLineEndingDifferences: true);
     }

--- a/test/VarDump.UnitTests/ReadonlyCollectionInitializerSpec.cs
+++ b/test/VarDump.UnitTests/ReadonlyCollectionInitializerSpec.cs
@@ -1,14 +1,19 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using VarDump.UnitTests.TestModel;
+using VarDump.Visitor;
 using Xunit;
 
 namespace VarDump.UnitTests;
 
 public class ReadonlyCollectionInitializerSpec
 {
-    [Fact(Skip = "Not implemented yet")]
+    [Fact]
     public void DumpReadonlyPropertyCollectionInitializerCSharp()
     {
-        CatOwner owner = new CatOwner
+        var owner = new ReadonlyCatCollectionOwner
         {
             Cats =
             {
@@ -18,24 +23,42 @@ public class ReadonlyCollectionInitializerSpec
             }
         };
 
-        var dumper = new CSharpDumper();
+        var dumper = new CSharpDumper(new DumpOptions
+        {
+            CollectionLiteralStyle = CollectionLiteralStyle.Initializer
+        });
 
         var result = dumper.Dump(owner);
 
         Assert.Equal(
             """
-            var arrayOfArrayOfInt = new int[][]
+            var readonlyCatCollectionOwner = new ReadonlyCatCollectionOwner
             {
-                new int[]
+                Cats =
                 {
-                    1
+                    new Cat
+                    {
+                        Age = 8,
+                        Name = "Sylvester"
+                    },
+                    new Cat
+                    {
+                        Age = 2,
+                        Name = "Whiskers"
+                    },
+                    new Cat
+                    {
+                        Age = 14,
+                        Name = "Sasha"
+                    }
                 }
             };
 
             """, result, ignoreLineEndingDifferences: true);
+        AssertCompiles(result);
     }
 
-    [Fact(Skip = "Not implemented yet")]
+    [Fact]
     public void DumpReadonlyPropertyDictionaryInitializerCSharp()
     {
         var owner = new CatDictionaryOwner
@@ -48,20 +71,127 @@ public class ReadonlyCollectionInitializerSpec
             }
         };
 
-        var dumper = new CSharpDumper();
+        var dumper = new CSharpDumper(new DumpOptions
+        {
+            CollectionLiteralStyle = CollectionLiteralStyle.Initializer
+        });
 
         var result = dumper.Dump(owner);
 
         Assert.Equal(
             """
-            var arrayOfArrayOfInt = new int[][]
+            var catDictionaryOwner = new CatDictionaryOwner
             {
-                new int[]
+                Cats =
                 {
-                    1
+                    {
+                        "Sylvester",
+                        new Cat
+                        {
+                            Age = 8,
+                            Name = "Sylvester"
+                        }
+                    },
+                    {
+                        "Whiskers",
+                        new Cat
+                        {
+                            Age = 2,
+                            Name = "Whiskers"
+                        }
+                    },
+                    {
+                        "Sasha",
+                        new Cat
+                        {
+                            Age = 14,
+                            Name = "Sasha"
+                        }
+                    }
                 }
             };
 
             """, result, ignoreLineEndingDifferences: true);
+        AssertCompiles(result);
+    }
+
+    [Fact]
+    public void SkipReadonlyPropertyCollectionInitializerVisualBasic()
+    {
+        var owner = new ReadonlyCatCollectionOwner
+        {
+            Cats =
+            {
+                new Cat { Name = "Sylvester", Age = 8 }
+            }
+        };
+
+        var dumper = new VisualBasicDumper(new DumpOptions
+        {
+            CollectionLiteralStyle = CollectionLiteralStyle.Initializer
+        });
+
+        var result = dumper.Dump(owner);
+
+        Assert.Equal(
+            "Dim readonlyCatCollectionOwnerValue = New ReadonlyCatCollectionOwner()\r\n",
+            result,
+            ignoreLineEndingDifferences: true);
+    }
+
+    [Fact]
+    public void SkipReadonlyPropertyDictionaryInitializerVisualBasic()
+    {
+        var owner = new CatDictionaryOwner
+        {
+            Cats =
+            {
+                ["Sylvester"] = new Cat { Name = "Sylvester", Age = 8 }
+            }
+        };
+
+        var dumper = new VisualBasicDumper(new DumpOptions
+        {
+            CollectionLiteralStyle = CollectionLiteralStyle.Initializer
+        });
+
+        var result = dumper.Dump(owner);
+
+        Assert.Equal(
+            "Dim catDictionaryOwnerValue = New CatDictionaryOwner()\r\n",
+            result,
+            ignoreLineEndingDifferences: true);
+    }
+
+    private static void AssertCompiles(string statement)
+    {
+        var source = $$"""
+                       using System.Collections.Generic;
+                       using VarDump.UnitTests.TestModel;
+
+                       public static class GeneratedReadonlyCollectionInitializer
+                       {
+                           public static void Create()
+                           {
+                       {{statement}}
+                           }
+                       }
+                       """;
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location))
+            .GroupBy(assembly => assembly.Location, StringComparer.OrdinalIgnoreCase)
+            .Select(group => MetadataReference.CreateFromFile(group.Key));
+        var compilation = CSharpCompilation.Create(
+            "GeneratedReadonlyCollectionInitializer_" + Guid.NewGuid().ToString("N"),
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest))],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var errors = compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+
+        Assert.True(errors.Length == 0,
+            string.Join(Environment.NewLine, errors.Select(error => error.ToString()))
+            + Environment.NewLine + source);
     }
 }

--- a/test/VarDump.UnitTests/TestModel/Collections.cs
+++ b/test/VarDump.UnitTests/TestModel/Collections.cs
@@ -27,6 +27,11 @@ namespace VarDump.UnitTests.TestModel
         public ICollection<Cat> Cats { get; init; } = new List<Cat>();
     }
 
+    public class ReadonlyCatCollectionOwner
+    {
+        public ICollection<Cat> Cats { get; } = new List<Cat>();
+    }
+
     public class CatPublicCollection : IEnumerable
     {
         private readonly ArrayList _list = new();


### PR DESCRIPTION
# Summary

This change expands C# collection-expression generation, adds valid initializer support for get-only collection properties, and introduces CI packaging for the VarDump NuGet packages.

## Changes

### C# collection expressions

- Emit collection expressions directly only when the runtime collection type is a valid C# target, including supported arrays, constructible collections with an applicable `Add` method, and collection-builder types.
- Preserve valid initializer-based output for dictionaries, multidimensional arrays, anonymous/grouping collections, and custom collections that cannot be constructed from a collection expression.
- Supply explicit targets when collection expressions are passed through LINQ, immutable, frozen, read-only, or non-public enumerable conversion paths.
- Add a cast when an initializer-free dump would otherwise produce a targetless collection expression.
- Keep nested, truncated, queryable, read-only, immutable, and frozen collection output compilable.

### Get-only collection properties

- Detect get-only C# collection and dictionary properties that can be populated through an applicable `Add` method.
- Route those values through collection/dictionary visitors that emit only the nested initializer body instead of assigning a new collection instance.
- Format the initializer opening brace on the line following the member assignment.
- Continue omitting these properties from Visual Basic output because VB does not support populating a read-only property from an object initializer.
- Document the C# initializer-mode exception to `IgnoreReadonlyProperties`.

### Packages and CI

- Bump `VarDump` and `VarDump.Extensions` from version 2.0.8 to 2.0.9.
- Add a Windows GitHub Actions workflow that restores, builds, and tests the solution on pushes, pull requests, and manual runs.
- Pack both projects and upload their `.nupkg` and `.snupkg` files as the `vardump-nuget-packages` workflow artifact. The workflow does not publish packages.

## Tests

- Add compile-backed coverage for direct collection expressions and required fallback/conversion paths.
- Add compile-backed C# tests for get-only collection and dictionary initializers.
- Add Visual Basic regression tests confirming unsupported read-only member initializers remain omitted.
- Validated the Release workflow commands locally across .NET 10 and .NET Framework 4.7.2:
  - `VarDump.UnitTests`: 457 passed, 5 skipped.
  - `VarDump.Extensions.UnitTests`: 6 passed.
  - Both `.nupkg` and `.snupkg` files were produced for each package.

## Compatibility note

`ICodeWriter` gains `SupportsReadonlyCollectionInitializers`, and `WriteMemberAssignmentStart` gains the optional `valueOnNewLine` parameter. Custom `ICodeWriter` implementations must implement the new capability and update the method signature.
